### PR TITLE
Add retro theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,21 @@
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: Tahoma, Arial, sans-serif;
+}
+
+/* Windows 95 inspired palette */
+.retro-theme {
+  --background: 0 0% 80%;
+  --foreground: 0 0% 0%;
+  --primary: 240 100% 40%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 0 0% 92%;
+  --secondary-foreground: 0 0% 10%;
+  --muted: 0 0% 85%;
+  --muted-foreground: 0 0% 20%;
+  --accent: 240 100% 90%;
+  --accent-foreground: 0 0% 10%;
 }
 
 @layer utilities {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,7 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
 import "./globals.css"
 import MainNavigation from '@/components/MainNavigation'
-
-const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   title: "ColdCase AI - Forensic Analysis Platform",
@@ -18,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={inter.className} suppressHydrationWarning>
+      <body className="retro-theme" suppressHydrationWarning>
         <MainNavigation />
         <main className="min-h-screen bg-gray-50">
           {children}


### PR DESCRIPTION
## Summary
- add Windows 95 inspired color palette and font stack
- remove Inter font and apply theme in layout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb5a908ec8325ae75e7f2802263de