### PR TITLE
Handle missing Anthropic API configuration gracefully

### DIFF
--- a/lib/ai-analysis.ts
+++ b/lib/ai-analysis.ts
@@ -1,8 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY!,
-});
+import { getAnthropicClient } from './anthropic-client';
 
 export interface TimelineEvent {
   id: string;
@@ -110,6 +106,8 @@ export async function analyzeCaseDocuments(
   const documentsText = documents.map((doc, idx) =>
     `=== DOCUMENT ${idx + 1}: ${doc.filename} (${doc.type}) ===\n${doc.content}\n`
   ).join('\n\n');
+
+  const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',

--- a/lib/anthropic-client.ts
+++ b/lib/anthropic-client.ts
@@ -1,0 +1,20 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+let anthropicInstance: Anthropic | null = null;
+
+export function getAnthropicClient(): Anthropic {
+  if (anthropicInstance) {
+    return anthropicInstance;
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY || process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+
+  if (!apiKey) {
+    throw new Error(
+      'Anthropic API key is not configured. Please set the ANTHROPIC_API_KEY environment variable.'
+    );
+  }
+
+  anthropicInstance = new Anthropic({ apiKey });
+  return anthropicInstance;
+}

--- a/lib/cold-case-analyzer.ts
+++ b/lib/cold-case-analyzer.ts
@@ -1,8 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY!,
-});
+import { getAnthropicClient } from './anthropic-client';
 
 // ============================================================================
 // 1. BEHAVIORAL PATTERN ANALYSIS
@@ -45,6 +41,8 @@ INTERVIEWS:
 ${interviews.map(i => `[${i.date}] ${i.speaker}:\n${i.content}`).join('\n\n')}
 
 Return JSON matching BehaviorPattern[] interface.`;
+
+  const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
@@ -153,6 +151,8 @@ Focus on evidence that STILL EXISTS or can still be obtained, even years later.
 
 Return JSON matching EvidenceGap[] interface.`;
 
+  const anthropic = getAnthropicClient();
+
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
     max_tokens: 8000,
@@ -231,6 +231,8 @@ Create a network map showing:
 
 Return JSON with nodes (RelationshipNode[]) and hiddenConnections (HiddenConnection[]).`;
 
+  const anthropic = getAnthropicClient();
+
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
     max_tokens: 8000,
@@ -307,6 +309,8 @@ PATTERNS TO CHECK:
 Calculate similarity scores and return matches.
 
 Return JSON matching CaseSimilarity[] interface.`;
+
+  const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
@@ -388,6 +392,8 @@ For each overlooked detail, explain:
 - What to do with it now
 
 Return JSON matching OverlookedDetail[] interface.`;
+
+  const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
@@ -477,6 +483,8 @@ For each question provide:
 
 Return JSON matching InterrogationStrategy interface.`;
 
+  const anthropic = getAnthropicClient();
+
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
     max_tokens: 8000,
@@ -540,6 +548,8 @@ For each piece of evidence, recommend:
 5. Priority level
 
 Return JSON matching ForensicReExamination[] interface.`;
+
+  const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',

--- a/lib/victim-timeline.ts
+++ b/lib/victim-timeline.ts
@@ -1,8 +1,4 @@
-import Anthropic from '@anthropic-ai/sdk';
-
-const anthropic = new Anthropic({
-  apiKey: process.env.ANTHROPIC_API_KEY!,
-});
+import { getAnthropicClient } from './anthropic-client';
 
 // ============================================================================
 // VICTIM LAST MOVEMENTS RECONSTRUCTION
@@ -242,6 +238,8 @@ Reconstruct the victim's timeline for the 24-48 hours preceding the incident. Fo
 
 Provide response as valid JSON only.`;
 
+  const anthropic = getAnthropicClient();
+
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
     max_tokens: 8000,
@@ -388,6 +386,8 @@ Each deviation could be significant - it might indicate:
 
 Return array of RoutineDeviation objects.`;
 
+  const anthropic = getAnthropicClient();
+
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
     max_tokens: 4000,
@@ -470,6 +470,8 @@ Focus on digital evidence that:
 
 Return JSON with footprints, lastCommunications, and suspiciousActivity arrays.`;
 
+  const anthropic = getAnthropicClient();
+
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',
     max_tokens: 4000,
@@ -549,6 +551,8 @@ GREEN FLAGS:
 Calculate credibility score and recommend reliability level.
 
 Return array of WitnessAccountValidation objects.`;
+
+  const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
     model: 'claude-3-5-sonnet-20241022',


### PR DESCRIPTION
## Summary
- add a shared Anthropic client helper that validates configuration before creating the SDK
- update analysis helpers to fetch the client lazily and reuse the shared instance
- provide a clearer error message when the Anthropic API key is missing to avoid opaque authentication failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69055a6c203883259e37420969a867ac