### PR TITLE
Fix case analysis timeline column name

### DIFF
--- a/app/analyses/page.tsx
+++ b/app/analyses/page.tsx
@@ -9,7 +9,7 @@ interface Analysis {
   id: string;
   case_id: string;
   analysis_type: string;
-  analysis_result: any;
+  analysis_data: any;
   created_at: string;
   updated_at: string;
   cases?: {
@@ -74,13 +74,13 @@ export default function AllAnalysesPage() {
   };
 
   const getAnalysisSummary = (analysis: Analysis): string => {
-    if (typeof analysis.analysis_result === 'string') {
-      return analysis.analysis_result.substring(0, 200) + '...';
+    if (typeof analysis.analysis_data === 'string') {
+      return analysis.analysis_data.substring(0, 200) + '...';
     }
-    if (analysis.analysis_result?.summary) {
-      return analysis.analysis_result.summary.substring(0, 200) + '...';
+    if (analysis.analysis_data?.summary) {
+      return analysis.analysis_data.summary.substring(0, 200) + '...';
     }
-    if (analysis.analysis_result?.findings) {
+    if (analysis.analysis_data?.findings) {
       return 'Analysis completed with findings';
     }
     return 'Analysis completed';

--- a/app/api/cases/[caseId]/timeline/route.ts
+++ b/app/api/cases/[caseId]/timeline/route.ts
@@ -104,7 +104,7 @@ export async function POST(
       .insert({
         case_id: caseId,
         analysis_type: 'timeline',
-        analysis_result: {
+        analysis_data: {
           timeline: analysis.timeline,
           conflicts: analysis.conflicts,
           personMentions: analysis.personMentions,


### PR DESCRIPTION
## Summary
- store timeline analysis output in the existing `analysis_data` column
- update the analyses listing page to read summaries from `analysis_data`

## Testing
- not run (requires non-interactive lint configuration)


------
https://chatgpt.com/codex/tasks/task_e_690802a83d1083259be78ac7b12264c6