### PR TITLE
Fix Anthropic model configuration for AI analyses

### DIFF
--- a/app/analyses/page.tsx
+++ b/app/analyses/page.tsx
@@ -1,4 +1,4 @@
-'use client'
+'use client';
 
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';

--- a/lib/ai-analysis.ts
+++ b/lib/ai-analysis.ts
@@ -1,4 +1,4 @@
-import { getAnthropicClient } from './anthropic-client';
+import { DEFAULT_ANTHROPIC_MODEL, getAnthropicClient } from './anthropic-client';
 
 export interface TimelineEvent {
   id: string;
@@ -110,7 +110,7 @@ export async function analyzeCaseDocuments(
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [
       {

--- a/lib/anthropic-client.ts
+++ b/lib/anthropic-client.ts
@@ -2,6 +2,11 @@ import Anthropic from '@anthropic-ai/sdk';
 
 let anthropicInstance: Anthropic | null = null;
 
+export const DEFAULT_ANTHROPIC_MODEL =
+  process.env.ANTHROPIC_MODEL ||
+  process.env.NEXT_PUBLIC_ANTHROPIC_MODEL ||
+  'claude-3-5-sonnet-20241022';
+
 export function getAnthropicClient(): Anthropic {
   if (anthropicInstance) {
     return anthropicInstance;

--- a/lib/cold-case-analyzer.ts
+++ b/lib/cold-case-analyzer.ts
@@ -1,4 +1,4 @@
-import { getAnthropicClient } from './anthropic-client';
+import { DEFAULT_ANTHROPIC_MODEL, getAnthropicClient } from './anthropic-client';
 
 // ============================================================================
 // 1. BEHAVIORAL PATTERN ANALYSIS
@@ -45,7 +45,7 @@ Return JSON matching BehaviorPattern[] interface.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -154,7 +154,7 @@ Return JSON matching EvidenceGap[] interface.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -234,7 +234,7 @@ Return JSON with nodes (RelationshipNode[]) and hiddenConnections (HiddenConnect
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -313,7 +313,7 @@ Return JSON matching CaseSimilarity[] interface.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -396,7 +396,7 @@ Return JSON matching OverlookedDetail[] interface.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -486,7 +486,7 @@ Return JSON matching InterrogationStrategy interface.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -552,7 +552,7 @@ Return JSON matching ForensicReExamination[] interface.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });

--- a/lib/victim-timeline.ts
+++ b/lib/victim-timeline.ts
@@ -1,4 +1,4 @@
-import { getAnthropicClient } from './anthropic-client';
+import { DEFAULT_ANTHROPIC_MODEL, getAnthropicClient } from './anthropic-client';
 
 // ============================================================================
 // VICTIM LAST MOVEMENTS RECONSTRUCTION
@@ -241,7 +241,7 @@ Provide response as valid JSON only.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 8000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -389,7 +389,7 @@ Return array of RoutineDeviation objects.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 4000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -473,7 +473,7 @@ Return JSON with footprints, lastCommunications, and suspiciousActivity arrays.`
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 4000,
     messages: [{ role: 'user', content: prompt }],
   });
@@ -555,7 +555,7 @@ Return array of WitnessAccountValidation objects.`;
   const anthropic = getAnthropicClient();
 
   const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
+    model: DEFAULT_ANTHROPIC_MODEL,
     max_tokens: 4000,
     messages: [{ role: 'user', content: prompt }],
   });


### PR DESCRIPTION
## Summary
- add a shared default Anthropics model constant that can be overridden by env vars
- update all AI analysis helpers to use the supported model id instead of a placeholder
- correct the client component directive formatting in the analyses page

## Testing
- not run (lint prompts for config interactively)


------
https://chatgpt.com/codex/tasks/task_e_69080988cb0883259ba1027405e17d7b