### PR TITLE
Review and fix analysis code endpoints

### DIFF
--- a/app/api/cases/[caseId]/timeline/route.ts
+++ b/app/api/cases/[caseId]/timeline/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase-client';
+import { supabaseServer } from '@/lib/supabase-server';
 import { analyzeCaseDocuments, detectTimeConflicts, identifyOverlookedSuspects, generateConflictSummary } from '@/lib/ai-analysis';
 
 export async function POST(
@@ -10,7 +10,7 @@ export async function POST(
     const { caseId } = params;
 
     // Fetch all case documents
-    const { data: documents, error: docError } = await supabase
+    const { data: documents, error: docError } = await supabaseServer
       .from('case_documents')
       .select('*')
       .eq('case_id', caseId);
@@ -41,7 +41,7 @@ export async function POST(
     analysis.conflicts.push(...timeConflicts);
 
     // Identify overlooked suspects
-    const { data: formalSuspects } = await supabase
+    const { data: formalSuspects } = await supabaseServer
       .from('suspects')
       .select('name')
       .eq('case_id', caseId);
@@ -65,7 +65,7 @@ export async function POST(
       status: 'verified',
     }));
 
-    const { error: timelineError } = await supabase
+    const { error: timelineError } = await supabaseServer
       .from('evidence_events')
       .insert(timelineInserts);
 
@@ -90,7 +90,7 @@ export async function POST(
       } as any,
     }));
 
-    const { error: flagError } = await supabase
+    const { error: flagError } = await supabaseServer
       .from('quality_flags')
       .insert(conflictInserts);
 
@@ -99,7 +99,7 @@ export async function POST(
     }
 
     // Save analysis results
-    const { error: analysisError } = await supabase
+    const { error: analysisError } = await supabaseServer
       .from('case_analysis')
       .insert({
         case_id: caseId,

--- a/app/api/cases/[caseId]/victim-timeline/route.ts
+++ b/app/api/cases/[caseId]/victim-timeline/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabase } from '@/lib/supabase-client';
+import { supabaseServer } from '@/lib/supabase-server';
 import { generateComprehensiveVictimTimeline } from '@/lib/victim-timeline';
 
 export async function POST(
@@ -28,7 +28,7 @@ export async function POST(
     }
 
     // Fetch case documents
-    const { data: documents, error: docError } = await supabase
+    const { data: documents, error: docError } = await supabaseServer
       .from('case_documents')
       .select('*')
       .eq('case_id', caseId);
@@ -38,7 +38,7 @@ export async function POST(
     }
 
     // Fetch case files (for evidence)
-    const { data: files } = await supabase
+    const { data: files } = await supabaseServer
       .from('case_files')
       .select('*')
       .eq('case_id', caseId);
@@ -86,7 +86,7 @@ export async function POST(
       priority: movement.significance,
     }));
 
-    const { error: timelineError } = await supabase
+    const { error: timelineError } = await supabaseServer
       .from('evidence_events')
       .insert(timelineInserts);
 
@@ -113,7 +113,7 @@ export async function POST(
       }));
 
     if (gapFlags.length > 0) {
-      const { error: flagError } = await supabase
+      const { error: flagError } = await supabaseServer
         .from('quality_flags')
         .insert(gapFlags);
 
@@ -123,7 +123,7 @@ export async function POST(
     }
 
     // Save complete analysis
-    const { error: analysisError } = await supabase
+    const { error: analysisError } = await supabaseServer
       .from('case_analysis')
       .insert({
         case_id: caseId,


### PR DESCRIPTION
- Replace supabase-client with supabaseServer in timeline/route.ts
- Replace supabase-client with supabaseServer in victim-timeline/route.ts
- Ensures API routes use service role key to bypass RLS
- Prevents "Row Level Security" errors that were blocking API calls

These routes were using the anonymous client which would fail with RLS policies enabled. Now they properly use the server-side client with service role permissions, matching the pattern used in analyze/route.ts and deep-analysis/route.ts.