### PR TITLE
Fix null event_title constraint violation

### DIFF
--- a/app/cases/[caseId]/analysis/page.tsx
+++ b/app/cases/[caseId]/analysis/page.tsx
@@ -88,14 +88,25 @@ export default function AnalysisPage() {
     setRunningAnalysis(analysisType);
 
     try {
-      const endpoint = `/api/cases/${caseId}/${analysisType}`;
+      // Map analysis types to their correct endpoints
+      let endpoint: string;
+      let body: any = {};
 
-      const body = analysisType === 'victim-timeline'
-        ? {
-            victimName: caseInfo?.victim_name || 'Unknown',
-            incidentTime: caseInfo?.incident_date || new Date().toISOString(),
-          }
-        : {};
+      if (analysisType === 'victim-timeline') {
+        endpoint = `/api/cases/${caseId}/victim-timeline`;
+        body = {
+          victimName: caseInfo?.victim_name || 'Unknown',
+          incidentTime: caseInfo?.incident_date || new Date().toISOString(),
+        };
+      } else if (analysisType === 'timeline' || analysisType === 'deep-analysis') {
+        // Timeline and deep analysis use the analyze endpoint
+        endpoint = `/api/cases/${caseId}/analyze`;
+        body = {};
+      } else {
+        // Default to using the analysis type as the endpoint path
+        endpoint = `/api/cases/${caseId}/${analysisType}`;
+        body = {};
+      }
 
       const response = await fetch(endpoint, {
         method: 'POST',


### PR DESCRIPTION
…lation

Fixed an issue where clicking "Timeline Analysis" would cause a database error: "null value in column event_title of relation timeline_events violates not-null constraint"

Root cause:
- The runAnalysis function was routing the 'timeline' analysis type to /api/cases/[caseId]/timeline
- This endpoint is designed for CRUD operations on individual timeline events and expects a full event object with a title field
- Instead, an empty body {} was being sent, causing the NOT NULL constraint violation

Solution:
- Updated runAnalysis to correctly route 'timeline' and 'deep-analysis' analysis types to /api/cases/[caseId]/analyze
- This endpoint performs actual document analysis and properly creates timeline events with all required fields
- The analyze endpoint extracts timeline events from case documents and saves them with proper titles

The fix ensures timeline analysis now calls the correct analysis endpoint rather than the timeline CRUD endpoint.