### PR TITLE
Fix case analysis API errors and missing resources

### DIFF
--- a/app/cases/[caseId]/analysis/page.tsx
+++ b/app/cases/[caseId]/analysis/page.tsx
@@ -98,9 +98,13 @@ export default function AnalysisPage() {
           victimName: caseInfo?.victim_name || 'Unknown',
           incidentTime: caseInfo?.incident_date || new Date().toISOString(),
         };
-      } else if (analysisType === 'timeline' || analysisType === 'deep-analysis') {
-        // Timeline and deep analysis use the analyze endpoint
+      } else if (analysisType === 'timeline') {
+        // Timeline uses the analyze endpoint
         endpoint = `/api/cases/${caseId}/analyze`;
+        body = {};
+      } else if (analysisType === 'deep-analysis') {
+        // Deep analysis has its own dedicated endpoint
+        endpoint = `/api/cases/${caseId}/deep-analysis`;
         body = {};
       } else {
         // Default to using the analysis type as the endpoint path


### PR DESCRIPTION
The deep-analysis feature was incorrectly routing to /api/cases/{id}/analyze instead of the dedicated /api/cases/{id}/deep-analysis endpoint, causing a 405 Method Not Allowed error. Separated the routing logic so that:
- 'timeline' → /api/cases/{id}/analyze
- 'deep-analysis' → /api/cases/{id}/deep-analysis

This fixes the "Failed to load resource: 405" error when running deep cold case analysis.