### PR TITLE
Fix deep analysis API returning 405 error

### DIFF
--- a/app/api/cases/[caseId]/alibis/route.ts
+++ b/app/api/cases/[caseId]/alibis/route.ts
@@ -10,10 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const { searchParams } = new URL(request.url);
     const subjectId = searchParams.get('subject_id');
 
@@ -38,10 +38,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const body = await request.json();
 
     const { data, error } = await supabaseServer

--- a/app/api/cases/[caseId]/analyze/route.ts
+++ b/app/api/cases/[caseId]/analyze/route.ts
@@ -5,10 +5,10 @@ import { extractMultipleDocuments, queueDocumentForReview } from '@/lib/document
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
 
     // Fetch all case documents
     const { data: documents, error: docError } = await supabaseServer

--- a/app/api/cases/[caseId]/board/populate/route.ts
+++ b/app/api/cases/[caseId]/board/populate/route.ts
@@ -9,10 +9,10 @@ import { sendInngestEvent } from '@/lib/inngest-client';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
 
     console.log(`[Board Population API] Triggering population for case: ${caseId}`);
 

--- a/app/api/cases/[caseId]/board/route.ts
+++ b/app/api/cases/[caseId]/board/route.ts
@@ -9,10 +9,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
 
     // Fetch all board data in parallel
     const [entitiesResult, connectionsResult, timelineResult, alibisResult, summaryResult] = await Promise.all([

--- a/app/api/cases/[caseId]/connections/route.ts
+++ b/app/api/cases/[caseId]/connections/route.ts
@@ -10,10 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
 
     const { data, error } = await supabaseServer
       .from('case_connections')
@@ -31,10 +31,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const body = await request.json();
 
     const { data, error } = await supabaseServer

--- a/app/api/cases/[caseId]/deep-analysis/route.ts
+++ b/app/api/cases/[caseId]/deep-analysis/route.ts
@@ -5,10 +5,10 @@ import { extractMultipleDocuments, queueDocumentForReview } from '@/lib/document
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
 
     console.log('Deep analysis requested for case:', caseId);
     console.log('Case ID type:', typeof caseId);

--- a/app/api/cases/[caseId]/entities/[entityId]/route.ts
+++ b/app/api/cases/[caseId]/entities/[entityId]/route.ts
@@ -11,10 +11,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string; entityId: string } }
+  context: { params: Promise<{ caseId: string; entityId: string }> }
 ) {
   try {
-    const { entityId } = params;
+    const { entityId } = await context.params;
 
     const { data: entity, error } = await supabaseServer
       .from('case_entities')
@@ -34,10 +34,10 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { caseId: string; entityId: string } }
+  context: { params: Promise<{ caseId: string; entityId: string }> }
 ) {
   try {
-    const { entityId } = params;
+    const { entityId } = await context.params;
     const body = await request.json();
 
     const updates = {
@@ -70,10 +70,10 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { caseId: string; entityId: string } }
+  context: { params: Promise<{ caseId: string; entityId: string }> }
 ) {
   try {
-    const { entityId } = params;
+    const { entityId } = await context.params;
 
     const { error } = await supabaseServer
       .from('case_entities')

--- a/app/api/cases/[caseId]/entities/route.ts
+++ b/app/api/cases/[caseId]/entities/route.ts
@@ -10,10 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const { searchParams } = new URL(request.url);
     const entityType = searchParams.get('type');
     const role = searchParams.get('role');
@@ -58,10 +58,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const body = await request.json();
 
     const {

--- a/app/api/cases/[caseId]/processing-jobs/route.ts
+++ b/app/api/cases/[caseId]/processing-jobs/route.ts
@@ -18,10 +18,10 @@ import {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const { searchParams } = new URL(request.url);
     const activeOnly = searchParams.get('active') === 'true';
     const statusFilter = searchParams.get('status');

--- a/app/api/cases/[caseId]/review-queue/route.ts
+++ b/app/api/cases/[caseId]/review-queue/route.ts
@@ -10,10 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
 
     // Get query parameters
     const url = new URL(request.url);

--- a/app/api/cases/[caseId]/search/route.ts
+++ b/app/api/cases/[caseId]/search/route.ts
@@ -20,10 +20,10 @@ const openai = new OpenAI({
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const body = await request.json();
     const {
       query,

--- a/app/api/cases/[caseId]/timeline/route.ts
+++ b/app/api/cases/[caseId]/timeline/route.ts
@@ -10,10 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const { searchParams } = new URL(request.url);
     const startDate = searchParams.get('start_date');
     const endDate = searchParams.get('end_date');
@@ -39,10 +39,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const body = await request.json();
 
     const { data, error } = await supabaseServer

--- a/app/api/cases/[caseId]/victim-timeline/route.ts
+++ b/app/api/cases/[caseId]/victim-timeline/route.ts
@@ -4,10 +4,10 @@ import { generateComprehensiveVictimTimeline } from '@/lib/victim-timeline';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> }
 ) {
   try {
-    const { caseId } = params;
+    const { caseId } = await context.params;
     const body = await request.json();
 
     // Get victim information from request


### PR DESCRIPTION
Updated all route handlers under /api/cases/[caseId]/ to properly handle params as Promises, which is required for Next.js 14+ compatibility. This fixes the 405 Method Not Allowed errors occurring with:
- Deep analysis endpoint
- Timeline analysis endpoint
- Victim timeline endpoint
- All other case-related API endpoints

Changes:
- Updated function signatures from `{ params }: { params: { caseId: string } }` to `context: { params: Promise<{ caseId: string }> }`
- Added `await context.params` to properly resolve params before use
- Applied fix to all 13 route files for consistency and future-proofing

This ensures all analysis endpoints (deep-analysis, analyze, victim-timeline, timeline) and other case routes work correctly without returning 405 errors.