### PR TITLE
Disable login requirement temporarily

### DIFF
--- a/app/api/review-queue/[reviewId]/route.ts
+++ b/app/api/review-queue/[reviewId]/route.ts
@@ -99,10 +99,10 @@ export async function PATCH(
 
     // If status is changing to 'in_review', set current user as assigned
     if (updates.status === 'in_review' && !updates.assigned_to) {
+      // Auth check disabled for testing
       const { data: { user } } = await supabaseServer.auth.getUser();
-      if (user) {
-        updates.assigned_to = user.id;
-      }
+      const userId = user?.id || '00000000-0000-0000-0000-000000000000';
+      updates.assigned_to = userId;
     }
 
     const { data, error } = await supabaseServer

--- a/app/api/review-queue/[reviewId]/submit/route.ts
+++ b/app/api/review-queue/[reviewId]/submit/route.ts
@@ -31,15 +31,19 @@ export async function POST(
       );
     }
 
+    // Auth check disabled for testing
     // Get current user
     const { data: { user } } = await supabaseServer.auth.getUser();
 
-    if (!user) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
+    // if (!user) {
+    //   return NextResponse.json(
+    //     { error: 'Unauthorized' },
+    //     { status: 401 }
+    //   );
+    // }
+
+    // Use default user ID when not authenticated (for testing)
+    const userId = user?.id || '00000000-0000-0000-0000-000000000000';
 
     // Get the review item
     const { data: reviewItem, error: fetchError } = await supabaseServer
@@ -76,7 +80,7 @@ export async function POST(
           corrected_text: correctedValue as string,
           document_type: 'handwritten_police_document', // Could be dynamic
           correction_type: segment.text === correctedValue ? 'confirmed_correct' : 'full_replacement',
-          corrected_by: user.id,
+          corrected_by: userId,
         });
 
         // Simple text replacement (in production, use position-aware replacement)
@@ -94,7 +98,7 @@ export async function POST(
         status: 'completed',
         corrections,
         review_notes: reviewNotes || null,
-        reviewed_by: user.id,
+        reviewed_by: userId,
         reviewed_at: new Date().toISOString(),
       })
       .eq('id', reviewId);
@@ -117,7 +121,7 @@ export async function POST(
             ...(reviewItem.document as any).metadata,
             human_reviewed: true,
             reviewed_at: new Date().toISOString(),
-            reviewed_by: user.id,
+            reviewed_by: userId,
             corrections_count: Object.keys(corrections).length,
           },
         })

--- a/app/cases/new/page.tsx
+++ b/app/cases/new/page.tsx
@@ -21,20 +21,24 @@ export default function NewCasePage() {
     setIsSubmitting(true);
 
     try {
+      // Auth check disabled for testing
       // Get current user
       const { data: { user } } = await supabase.auth.getUser();
 
-      if (!user) {
-        alert('You must be logged in to create a case');
-        router.push('/login');
-        return;
-      }
+      // if (!user) {
+      //   alert('You must be logged in to create a case');
+      //   router.push('/login');
+      //   return;
+      // }
+
+      // Use default user ID when not authenticated (for testing)
+      const userId = user?.id || '00000000-0000-0000-0000-000000000000';
 
       // Get user's agency membership
       const { data: membership } = await supabase
         .from('agency_members')
         .select('agency_id')
-        .eq('user_id', user.id)
+        .eq('user_id', userId)
         .limit(1)
         .single();
 
@@ -46,7 +50,7 @@ export default function NewCasePage() {
         .from('cases')
         .insert({
           ...formData,
-          user_id: user.id,
+          user_id: userId,
           agency_id: agency_id,
         })
         .select()

--- a/components/FreshEyesPlatform.tsx
+++ b/components/FreshEyesPlatform.tsx
@@ -60,12 +60,13 @@ const FreshEyesPlatform = () => {
   }, []);
 
   const checkAuthAndFetchData = async () => {
-    const { data: { session } } = await supabase.auth.getSession();
-    if (!session) {
-      console.warn('No active session, redirecting to login...');
-      router.push('/login');
-      return;
-    }
+    // Auth check disabled for testing
+    // const { data: { session } } = await supabase.auth.getSession();
+    // if (!session) {
+    //   console.warn('No active session, redirecting to login...');
+    //   router.push('/login');
+    //   return;
+    // }
     fetchCases();
     fetchStats();
   };


### PR DESCRIPTION
Commented out authentication checks in:
- FreshEyesPlatform component (main dashboard)
- New case creation page
- Review queue API routes

All auth checks now use default/fallback user IDs when not authenticated, allowing testing without login requirement.