### PR TITLE
Remove outdated evidence file from deployment

### DIFF
--- a/app/analyses/page.tsx
+++ b/app/analyses/page.tsx
@@ -13,8 +13,8 @@ interface Analysis {
   created_at: string;
   updated_at: string;
   cases?: {
-    case_name?: string;
-    case_number?: string;
+    name: string;
+    title: string;
   };
 }
 
@@ -35,8 +35,8 @@ export default function AllAnalysesPage() {
       .select(`
         *,
         cases (
-          case_name,
-          case_number
+          name,
+          title
         )
       `)
       .order('created_at', { ascending: false });
@@ -153,7 +153,7 @@ export default function AllAnalysesPage() {
                                 onClick={() => router.push(`/cases/${analysis.case_id}`)}
                                 className="text-sm text-blue-600 hover:text-blue-700 font-medium"
                               >
-                                {analysis.cases.case_name || analysis.cases.case_number || 'View Case'}
+                                {analysis.cases.title || analysis.cases.name || 'View Case'}
                               </button>
                             )}
                           </div>

--- a/app/api/review-queue/[reviewId]/route.ts
+++ b/app/api/review-queue/[reviewId]/route.ts
@@ -31,7 +31,7 @@ export async function GET(
         ),
         case:cases!case_id (
           id,
-          case_number,
+          name,
           title
         )
       `)

--- a/app/cases/[caseId]/analysis/page.tsx
+++ b/app/cases/[caseId]/analysis/page.tsx
@@ -332,7 +332,7 @@ export default function AnalysisPage() {
               <h1 className="text-3xl font-bold text-gray-900">AI Analysis Center</h1>
               {caseInfo && (
                 <p className="text-gray-600 mt-1">
-                  {caseInfo.case_name || `Case #${caseInfo.case_number}`}
+                  {caseInfo.title || caseInfo.name}
                 </p>
               )}
             </div>

--- a/app/cases/[caseId]/files/page.tsx
+++ b/app/cases/[caseId]/files/page.tsx
@@ -183,7 +183,7 @@ export default function CaseFilesPage() {
               <h1 className="text-3xl font-bold text-gray-900">Case Files</h1>
               {caseInfo && (
                 <p className="text-gray-600 mt-1">
-                  {caseInfo.case_name || `Case #${caseInfo.case_number}`}
+                  {caseInfo.title || caseInfo.name}
                 </p>
               )}
             </div>

--- a/app/cases/[caseId]/page.tsx
+++ b/app/cases/[caseId]/page.tsx
@@ -21,8 +21,8 @@ import {
 
 interface CaseData {
   id: string;
-  case_number?: string;
-  case_name?: string;
+  name: string;
+  title: string;
   description: string | null;
   incident_date?: string | null;
   status: string;
@@ -179,7 +179,7 @@ export default function CaseDetailPage() {
             <div>
               <div className="flex items-center gap-3 mb-2">
                 <h1 className="text-3xl font-bold text-gray-900">
-                  {caseData.case_name || `Case #${caseData.case_number}`}
+                  {caseData.title || caseData.name}
                 </h1>
                 <span className={`px-3 py-1 rounded-full text-sm font-medium ${getStatusBadgeClass(caseData.status)}`}>
                   {caseData.status.charAt(0).toUpperCase() + caseData.status.slice(1)}
@@ -188,8 +188,8 @@ export default function CaseDetailPage() {
                   {caseData.priority.charAt(0).toUpperCase() + caseData.priority.slice(1)} Priority
                 </span>
               </div>
-              {caseData.case_number && (
-                <p className="text-gray-600">Case Number: {caseData.case_number}</p>
+              {caseData.name && (
+                <p className="text-gray-600">Case Name: {caseData.name}</p>
               )}
             </div>
           </div>

--- a/app/cases/page.tsx
+++ b/app/cases/page.tsx
@@ -7,8 +7,8 @@ import { FileText, Calendar, Plus, ArrowLeft } from 'lucide-react';
 
 interface Case {
   id: string;
-  case_number?: string;
-  case_name?: string;
+  name: string;
+  title: string;
   description: string | null;
   incident_date?: string | null;
   status: string;
@@ -206,7 +206,7 @@ export default function AllCasesPage() {
                     <div className="flex-1">
                       <div className="flex items-center space-x-3 mb-2">
                         <h4 className="text-lg font-medium text-gray-900">
-                          {case_.case_name || case_.case_number}
+                          {case_.title || case_.name}
                         </h4>
                         <StatusBadge status={case_.status} />
                         <PriorityBadge priority={case_.priority} />

--- a/app/evidence/page.tsx
+++ b/app/evidence/page.tsx
@@ -16,8 +16,8 @@ interface CaseDocument {
   updated_at: string;
   user_id: string;
   cases?: {
-    case_name?: string;
-    case_number?: string;
+    name: string;
+    title: string;
   };
 }
 
@@ -38,8 +38,8 @@ export default function AllEvidencePage() {
       .select(`
         *,
         cases (
-          case_name,
-          case_number
+          name,
+          title
         )
       `)
       .order('created_at', { ascending: false });
@@ -143,7 +143,7 @@ export default function AllEvidencePage() {
                                 onClick={() => router.push(`/cases/${doc.case_id}`)}
                                 className="text-sm text-blue-600 hover:text-blue-700 font-medium"
                               >
-                                {doc.cases.case_name || doc.cases.case_number || 'View Case'}
+                                {doc.cases.title || doc.cases.name || 'View Case'}
                               </button>
                             </>
                           )}

--- a/components/FreshEyesPlatform.tsx
+++ b/components/FreshEyesPlatform.tsx
@@ -7,10 +7,8 @@ import { useRouter } from 'next/navigation';
 
 interface Case {
   id: string;
-  case_number?: string;
-  case_name?: string;
-  name?: string;
-  title?: string;
+  name: string;
+  title: string;
   description: string | null;
   incident_date?: string | null;
   lastUpdated?: string;
@@ -287,7 +285,7 @@ const FreshEyesPlatform = () => {
                   <div className="flex-1">
                     <div className="flex items-center space-x-3 mb-2">
                       <h4 className="text-lg font-medium text-gray-900">
-                        {case_.case_name || case_.case_number}
+                        {case_.title || case_.name}
                       </h4>
                       <StatusBadge status={case_.status} />
                       <PriorityBadge priority={case_.priority} />
@@ -335,7 +333,7 @@ const FreshEyesPlatform = () => {
           <div className="flex items-start justify-between mb-4">
             <div>
               <h1 className="text-2xl font-bold text-gray-900 mb-2">
-                {selectedCase.case_name || selectedCase.case_number}
+                {selectedCase.title || selectedCase.name}
               </h1>
               {selectedCase.description && (
                 <p className="text-gray-600">{selectedCase.description}</p>
@@ -349,8 +347,8 @@ const FreshEyesPlatform = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6">
             <div className="space-y-2">
-              <p className="text-sm font-medium text-gray-500">Case Number</p>
-              <p className="text-lg text-gray-900">{selectedCase.case_number}</p>
+              <p className="text-sm font-medium text-gray-500">Case Name</p>
+              <p className="text-lg text-gray-900">{selectedCase.name}</p>
             </div>
             <div className="space-y-2">
               <p className="text-sm font-medium text-gray-500">Incident Date</p>


### PR DESCRIPTION
The frontend was trying to access non-existent fields (case_name/case_number) while the database schema uses 'name' and 'title' fields. This caused cases to not display properly even though they existed in the database with their associated evidence files.

Changes:
- Updated all Case interfaces to use 'name' and 'title' instead of 'case_name' and 'case_number'
- Fixed display logic to show case.title || case.name
- Updated Supabase queries to select correct field names
- Fixed all affected pages: cases list, evidence, analyses, case details, and API routes

This resolves the issue where evidence files were visible (1 file) but cases showed as 0 because the display code couldn't find the case data.