### PR TITLE
Debug persistent deployment failures

### DIFF
--- a/app/api/cases/[caseId]/alibis/route.ts
+++ b/app/api/cases/[caseId]/alibis/route.ts
@@ -10,9 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const { searchParams } = new URL(request.url);
     const subjectId = searchParams.get('subject_id');
@@ -38,9 +39,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const body = await request.json();
 

--- a/app/api/cases/[caseId]/analyze/route.ts
+++ b/app/api/cases/[caseId]/analyze/route.ts
@@ -5,9 +5,11 @@ import { extractMultipleDocuments, queueDocumentForReview } from '@/lib/document
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    // Handle both sync and async params for Next.js 14/15 compatibility
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
 
     // Fetch all case documents

--- a/app/api/cases/[caseId]/board/populate/route.ts
+++ b/app/api/cases/[caseId]/board/populate/route.ts
@@ -9,9 +9,10 @@ import { sendInngestEvent } from '@/lib/inngest-client';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
 
     console.log(`[Board Population API] Triggering population for case: ${caseId}`);

--- a/app/api/cases/[caseId]/board/route.ts
+++ b/app/api/cases/[caseId]/board/route.ts
@@ -9,9 +9,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
 
     // Fetch all board data in parallel

--- a/app/api/cases/[caseId]/connections/route.ts
+++ b/app/api/cases/[caseId]/connections/route.ts
@@ -10,9 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
 
     const { data, error } = await supabaseServer
@@ -31,9 +32,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const body = await request.json();
 

--- a/app/api/cases/[caseId]/deep-analysis/route.ts
+++ b/app/api/cases/[caseId]/deep-analysis/route.ts
@@ -5,9 +5,11 @@ import { extractMultipleDocuments, queueDocumentForReview } from '@/lib/document
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    // Handle both sync and async params for Next.js 14/15 compatibility
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
 
     console.log('Deep analysis requested for case:', caseId);

--- a/app/api/cases/[caseId]/entities/[entityId]/route.ts
+++ b/app/api/cases/[caseId]/entities/[entityId]/route.ts
@@ -11,10 +11,11 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string; entityId: string } }
+  context: { params: Promise<{ caseId: string; entityId: string }> | { caseId: string; entityId: string } }
 ) {
   try {
-    const { entityId } = await context.params;
+    const params = await Promise.resolve(context.params);
+    const { entityId } = params;
 
     const { data: entity, error } = await supabaseServer
       .from('case_entities')
@@ -34,10 +35,11 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { caseId: string; entityId: string } }
+  context: { params: Promise<{ caseId: string; entityId: string }> | { caseId: string; entityId: string } }
 ) {
   try {
-    const { entityId } = await context.params;
+    const params = await Promise.resolve(context.params);
+    const { entityId } = params;
     const body = await request.json();
 
     const updates = {
@@ -70,10 +72,11 @@ export async function PUT(
 
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { caseId: string; entityId: string } }
+  context: { params: Promise<{ caseId: string; entityId: string }> | { caseId: string; entityId: string } }
 ) {
   try {
-    const { entityId } = await context.params;
+    const params = await Promise.resolve(context.params);
+    const { entityId } = params;
 
     const { error } = await supabaseServer
       .from('case_entities')

--- a/app/api/cases/[caseId]/entities/route.ts
+++ b/app/api/cases/[caseId]/entities/route.ts
@@ -10,9 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const { searchParams } = new URL(request.url);
     const entityType = searchParams.get('type');
@@ -58,9 +59,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const body = await request.json();
 

--- a/app/api/cases/[caseId]/processing-jobs/route.ts
+++ b/app/api/cases/[caseId]/processing-jobs/route.ts
@@ -18,9 +18,10 @@ import {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const { searchParams } = new URL(request.url);
     const activeOnly = searchParams.get('active') === 'true';

--- a/app/api/cases/[caseId]/review-queue/route.ts
+++ b/app/api/cases/[caseId]/review-queue/route.ts
@@ -10,9 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
 
     // Get query parameters

--- a/app/api/cases/[caseId]/search/route.ts
+++ b/app/api/cases/[caseId]/search/route.ts
@@ -20,9 +20,10 @@ const openai = new OpenAI({
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const body = await request.json();
     const {

--- a/app/api/cases/[caseId]/timeline/route.ts
+++ b/app/api/cases/[caseId]/timeline/route.ts
@@ -10,9 +10,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const { searchParams } = new URL(request.url);
     const startDate = searchParams.get('start_date');
@@ -39,9 +40,10 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const body = await request.json();
 

--- a/app/api/cases/[caseId]/victim-timeline/route.ts
+++ b/app/api/cases/[caseId]/victim-timeline/route.ts
@@ -4,9 +4,10 @@ import { generateComprehensiveVictimTimeline } from '@/lib/victim-timeline';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { caseId: string } }
+  context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const body = await request.json();
 

--- a/app/api/processing-jobs/[jobId]/chunks/route.ts
+++ b/app/api/processing-jobs/[jobId]/chunks/route.ts
@@ -13,9 +13,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { jobId: string } }
+  context: { params: Promise<{ jobId: string }> | { jobId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { jobId } = params;
     const { searchParams } = new URL(request.url);
     const statusFilter = searchParams.get('status');

--- a/app/api/processing-jobs/[jobId]/retry/route.ts
+++ b/app/api/processing-jobs/[jobId]/retry/route.ts
@@ -12,9 +12,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { jobId: string } }
+  context: { params: Promise<{ jobId: string }> | { jobId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { jobId } = params;
 
     if (!jobId) {

--- a/app/api/processing-jobs/[jobId]/route.ts
+++ b/app/api/processing-jobs/[jobId]/route.ts
@@ -13,9 +13,10 @@ import { getProcessingSummary } from '@/lib/progress-tracker';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { jobId: string } }
+  context: { params: Promise<{ jobId: string }> | { jobId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { jobId } = params;
 
     if (!jobId) {

--- a/app/api/review-queue/[reviewId]/route.ts
+++ b/app/api/review-queue/[reviewId]/route.ts
@@ -9,9 +9,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { reviewId: string } }
+  context: { params: Promise<{ reviewId: string }> | { reviewId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { reviewId } = params;
 
     console.log(`[Review Queue API] Fetching review item ${reviewId}`);
@@ -79,9 +80,10 @@ export async function GET(
 
 export async function PATCH(
   request: NextRequest,
-  { params }: { params: { reviewId: string } }
+  context: { params: Promise<{ reviewId: string }> | { reviewId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { reviewId } = params;
     const body = await request.json();
 

--- a/app/api/review-queue/[reviewId]/submit/route.ts
+++ b/app/api/review-queue/[reviewId]/submit/route.ts
@@ -14,9 +14,10 @@ import { supabaseServer } from '@/lib/supabase-server';
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { reviewId: string } }
+  context: { params: Promise<{ reviewId: string }> | { reviewId: string } }
 ) {
   try {
+    const params = await Promise.resolve(context.params);
     const { reviewId } = params;
     const body = await request.json();
 


### PR DESCRIPTION
…rectly

This commit fixes 405 (Method Not Allowed) errors occurring on Vercel deployments by updating all dynamic route handlers to support both synchronous and asynchronous params patterns in Next.js 14.

Changes:
- Updated 18 API route files with dynamic params ([caseId], [reviewId], [jobId])
- Changed function signatures from destructured params to context object
- Added Promise.resolve() wrapper to handle both sync/async params safely
- Affects routes: analyze, deep-analysis, timeline, entities, alibis, board, connections, search, review-queue, processing-jobs, and more

This resolves the issue where API endpoints were returning 405 errors instead of executing POST/GET/PUT/DELETE handlers correctly on production.