### PR TITLE
Queue victim timeline analysis via background job

### DIFF
--- a/app/api/inngest/route.ts
+++ b/app/api/inngest/route.ts
@@ -22,6 +22,7 @@ import {
 } from '@/lib/jobs/process-document-chunks';
 
 import { populateInvestigationBoardJob } from '@/lib/jobs/populate-investigation-board';
+import { processVictimTimelineJob } from '@/lib/jobs/victim-timeline';
 
 /**
  * Register all Inngest functions (jobs) here
@@ -32,6 +33,7 @@ const inngestFunctions = [
   aggregateDocumentJob,
   generateEmbeddingsJob,
   populateInvestigationBoardJob,
+  processVictimTimelineJob,
 ];
 
 /**

--- a/app/cases/[caseId]/analysis/page.tsx
+++ b/app/cases/[caseId]/analysis/page.tsx
@@ -147,13 +147,22 @@ export default function AnalysisPage() {
             return;
           }
         } else if (analysisType === 'victim-timeline') {
-          const viewBoard = confirm(
-            'Victim timeline reconstruction completed successfully!\n\n' +
-            'Click OK to view the timeline on the Investigation Board, or Cancel to stay here.'
-          );
-          if (viewBoard) {
-            router.push(`/cases/${caseId}/board`);
-            return;
+          if (result.jobId) {
+            alert(
+              [
+                'Victim timeline reconstruction has been scheduled.',
+                'Track progress from the Processing Jobs panel or refresh this page once complete.',
+              ].join(' ')
+            );
+          } else {
+            const viewBoard = confirm(
+              'Victim timeline reconstruction completed successfully!\n\n' +
+              'Click OK to view the timeline on the Investigation Board, or Cancel to stay here.'
+            );
+            if (viewBoard) {
+              router.push(`/cases/${caseId}/board`);
+              return;
+            }
           }
         } else {
           alert(`${analysisType} completed successfully!`);

--- a/app/cases/[caseId]/files/page.tsx
+++ b/app/cases/[caseId]/files/page.tsx
@@ -110,10 +110,24 @@ export default function CaseFilesPage() {
 
       const result = await response.json();
 
-      if (result.success) {
-        alert(`${analysisType} analysis completed successfully!`);
-      } else {
+      if (!result.success) {
         alert(`Analysis failed: ${result.error}`);
+        return;
+      }
+
+      if (analysisType === 'victim-timeline') {
+        if (result.jobId) {
+          alert(
+            [
+              'Victim timeline reconstruction has been scheduled.',
+              'You can monitor progress from the Processing Jobs panel.',
+            ].join(' ')
+          );
+        } else {
+          alert('Victim timeline analysis completed successfully!');
+        }
+      } else {
+        alert(`${analysisType} analysis completed successfully!`);
       }
     } catch (error) {
       console.error('Analysis error:', error);

--- a/lib/inngest-client.ts
+++ b/lib/inngest-client.ts
@@ -90,6 +90,26 @@ type Events = {
     };
   };
 
+  // Triggered to run the long-form victim timeline reconstruction
+  'analysis/victim-timeline': {
+    data: {
+      jobId: string;
+      caseId: string;
+      victimInfo: {
+        name: string;
+        incidentTime: string;
+        incidentLocation?: string | null;
+        typicalRoutine?: string | null;
+        knownHabits?: string | null;
+        regularContacts?: string[] | null;
+      };
+      requestContext?: {
+        digitalRecords?: any;
+      };
+      requestedAt: string;
+    };
+  };
+
   // Triggered to populate Investigation Board from case documents
   'board/populate': {
     data: {

--- a/lib/jobs/victim-timeline.ts
+++ b/lib/jobs/victim-timeline.ts
@@ -1,0 +1,241 @@
+import { inngest } from '@/lib/inngest-client';
+import { supabaseServer } from '@/lib/supabase-server';
+import { generateComprehensiveVictimTimeline } from '@/lib/victim-timeline';
+
+interface VictimTimelineEventData {
+  jobId: string;
+  caseId: string;
+  victimInfo: {
+    name: string;
+    incidentTime: string;
+    incidentLocation?: string | null;
+    typicalRoutine?: string | null;
+    knownHabits?: string | null;
+    regularContacts?: string[] | null;
+  };
+  requestContext?: {
+    digitalRecords?: any;
+  };
+  requestedAt: string;
+}
+
+async function updateProcessingJob(
+  jobId: string,
+  updates: Record<string, any>
+) {
+  const { error } = await supabaseServer
+    .from('processing_jobs')
+    .update(updates)
+    .eq('id', jobId);
+
+  if (error) {
+    console.error('[VictimTimelineJob] Failed to update job', jobId, error);
+  }
+}
+
+export const processVictimTimelineJob = inngest.createFunction(
+  {
+    id: 'victim-timeline-generate',
+    name: 'Generate Victim Timeline Reconstruction',
+    retries: 2,
+    concurrency: {
+      limit: 2,
+    },
+  },
+  { event: 'analysis/victim-timeline' },
+  async ({ event, step }) => {
+    const { jobId, caseId, victimInfo, requestContext, requestedAt } =
+      event.data as VictimTimelineEventData;
+
+    const totalUnits = 4;
+    const initialMetadata = {
+      analysisType: 'victim_timeline',
+      victimName: victimInfo.name,
+      incidentTime: victimInfo.incidentTime,
+      incidentLocation: victimInfo.incidentLocation,
+      requestedAt,
+    };
+
+    try {
+      await step.run('initialize-job', async () => {
+        await updateProcessingJob(jobId, {
+          status: 'running',
+          total_units: totalUnits,
+          started_at: new Date().toISOString(),
+          metadata: initialMetadata,
+        });
+      });
+
+      const { documents, files } = await step.run('fetch-case-data', async () => {
+        const { data: documents, error: docError } = await supabaseServer
+          .from('case_documents')
+          .select('*')
+          .eq('case_id', caseId);
+
+        if (docError) {
+          throw new Error(`Failed to fetch case documents: ${docError.message}`);
+        }
+
+        const { data: files, error: fileError } = await supabaseServer
+          .from('case_files')
+          .select('*')
+          .eq('case_id', caseId);
+
+        if (fileError) {
+          throw new Error(`Failed to fetch case files: ${fileError.message}`);
+        }
+
+        await updateProcessingJob(jobId, {
+          completed_units: 1,
+          progress_percentage: Math.round((1 / totalUnits) * 100),
+        });
+
+        return { documents: documents || [], files: files || [] };
+      });
+
+      const docsForAnalysis = documents.map(doc => ({
+        filename: doc.file_name,
+        content: `[Document content would be loaded from: ${doc.storage_path}]`,
+        type: doc.document_type as any,
+      }));
+
+      const caseData = {
+        documents: docsForAnalysis,
+        witnesses: [],
+        digitalRecords: requestContext?.digitalRecords || undefined,
+        physicalEvidence: files.map(file => file.file_name),
+      };
+
+      const analysisResult = await step.run('generate-timeline', async () => {
+        const result = await generateComprehensiveVictimTimeline(
+          {
+            name: victimInfo.name,
+            incidentTime: victimInfo.incidentTime,
+            incidentLocation: victimInfo.incidentLocation || undefined,
+            typicalRoutine: victimInfo.typicalRoutine || undefined,
+            knownHabits: victimInfo.knownHabits || undefined,
+            regularContacts: victimInfo.regularContacts || undefined,
+          },
+          caseData
+        );
+
+        await updateProcessingJob(jobId, {
+          completed_units: 2,
+          progress_percentage: Math.round((2 / totalUnits) * 100),
+        });
+
+        return result;
+      });
+
+      await step.run('persist-results', async () => {
+        const timelineInserts = analysisResult.timeline.movements.map(movement => ({
+          case_id: caseId,
+          title: movement.activity.substring(0, 100),
+          description: movement.activity,
+          type: 'victim_movement',
+          date: movement.timestamp.split('T')[0],
+          time: new Date(movement.timestamp).toLocaleTimeString(),
+          location: movement.location,
+          personnel: [...movement.witnessedBy, ...movement.accompaniedBy].join(', '),
+          tags: [...movement.witnessedBy, ...movement.accompaniedBy],
+          status: movement.significance,
+          priority: movement.significance,
+        }));
+
+        if (timelineInserts.length > 0) {
+          const { error: timelineError } = await supabaseServer
+            .from('evidence_events')
+            .insert(timelineInserts);
+
+          if (timelineError) {
+            console.error('[VictimTimelineJob] Error saving timeline:', timelineError);
+          }
+        }
+
+        const gapFlags = analysisResult.timeline.timelineGaps
+          .filter(gap => gap.significance === 'critical' || gap.significance === 'high')
+          .map(gap => ({
+            case_id: caseId,
+            type: 'missing_data' as const,
+            severity: gap.significance as 'low' | 'medium' | 'high' | 'critical',
+            title: `Timeline gap: ${gap.durationMinutes} minutes unaccounted`,
+            description: `Victim's whereabouts unknown between ${gap.lastKnownLocation} and ${gap.nextKnownLocation}`,
+            recommendation: gap.questionsToAnswer.join('; '),
+            metadata: {
+              startTime: gap.startTime,
+              endTime: gap.endTime,
+              durationMinutes: gap.durationMinutes,
+              potentialEvidence: gap.potentialEvidence,
+            } as any,
+          }));
+
+        if (gapFlags.length > 0) {
+          const { error: flagError } = await supabaseServer
+            .from('quality_flags')
+            .insert(gapFlags);
+
+          if (flagError) {
+            console.error('[VictimTimelineJob] Error saving gap flags:', flagError);
+          }
+        }
+
+        const { error: analysisError } = await supabaseServer
+          .from('case_analysis')
+          .insert({
+            case_id: caseId,
+            analysis_type: 'victim_timeline',
+            analysis_data: analysisResult as any,
+            confidence_score: 0.85,
+            used_prompt: 'Victim last movements reconstruction with gap analysis',
+          });
+
+        if (analysisError) {
+          console.error('[VictimTimelineJob] Error saving analysis:', analysisError);
+        }
+
+        await updateProcessingJob(jobId, {
+          completed_units: 3,
+          progress_percentage: Math.round((3 / totalUnits) * 100),
+        });
+      });
+
+      await step.run('finalize-job', async () => {
+        await updateProcessingJob(jobId, {
+          status: 'completed',
+          completed_units: totalUnits,
+          progress_percentage: 100,
+          completed_at: new Date().toISOString(),
+          metadata: {
+            ...initialMetadata,
+            timelineSummary: {
+              totalMovements: analysisResult.timeline.movements.length,
+              criticalGaps: analysisResult.timeline.timelineGaps.filter(
+                gap => gap.significance === 'critical'
+              ).length,
+            },
+          },
+        });
+      });
+
+      return {
+        success: true,
+        jobId,
+      };
+    } catch (error: any) {
+      await updateProcessingJob(jobId, {
+        status: 'failed',
+        completed_units: totalUnits,
+        failed_units: 1,
+        progress_percentage: 100,
+        completed_at: new Date().toISOString(),
+        metadata: {
+          ...initialMetadata,
+          error: error?.message || 'Victim timeline analysis failed',
+        },
+      });
+
+      console.error('[VictimTimelineJob] Failed to process victim timeline:', error);
+      throw error;
+    }
+  }
+);


### PR DESCRIPTION
## Summary
- change the victim timeline API to schedule a processing job, validate the Anthropic key up front, and dispatch an Inngest event instead of blocking on LLM calls
- add an Inngest worker that fetches case context, generates the Anthropic analysis with timeouts, and persists the resulting timeline and flags
- update client screens to treat the timeline request as asynchronous and report when a background job is created

## Testing
- `npm run lint` *(fails: command requires interactive configuration and cannot run non-interactively)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691026f65138832592cd1ddb5ed1a84c)