### PR TITLE
Fix processing job progress updates

### DIFF
--- a/lib/jobs/behavioral-patterns.ts
+++ b/lib/jobs/behavioral-patterns.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { analyzeBehavioralPatterns } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
@@ -16,14 +17,7 @@ interface BehavioralPatternsEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[BehavioralPatternsJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'BehavioralPatternsJob');
 }
 
 export const processBehavioralPatternsJob = inngest.createFunction(

--- a/lib/jobs/deep-analysis.ts
+++ b/lib/jobs/deep-analysis.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { performComprehensiveAnalysis } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments, queueDocumentForReview } from '@/lib/document-parser';
 
@@ -16,14 +17,7 @@ interface DeepAnalysisEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[DeepAnalysisJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'DeepAnalysisJob');
 }
 
 export const processDeepAnalysisJob = inngest.createFunction(

--- a/lib/jobs/evidence-gaps.ts
+++ b/lib/jobs/evidence-gaps.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { identifyEvidenceGaps } from '@/lib/cold-case-analyzer';
 
 interface EvidenceGapsEventData {
@@ -15,14 +16,7 @@ interface EvidenceGapsEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[EvidenceGapsJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'EvidenceGapsJob');
 }
 
 export const processEvidenceGapsJob = inngest.createFunction(

--- a/lib/jobs/forensic-retesting.ts
+++ b/lib/jobs/forensic-retesting.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { recommendForensicRetesting } from '@/lib/cold-case-analyzer';
 
 interface ForensicRetestingEventData {
@@ -15,14 +16,7 @@ interface ForensicRetestingEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[ForensicRetestingJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'ForensicRetestingJob');
 }
 
 export const processForensicRetestingJob = inngest.createFunction(

--- a/lib/jobs/interrogation-questions.ts
+++ b/lib/jobs/interrogation-questions.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { generateInterrogationQuestions } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
@@ -16,14 +17,7 @@ interface InterrogationQuestionsEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[InterrogationQuestionsJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'InterrogationQuestionsJob');
 }
 
 export const processInterrogationQuestionsJob = inngest.createFunction(

--- a/lib/jobs/overlooked-details.ts
+++ b/lib/jobs/overlooked-details.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { findOverlookedDetails } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
@@ -16,14 +17,7 @@ interface OverlookedDetailsEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[OverlookedDetailsJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'OverlookedDetailsJob');
 }
 
 export const processOverlookedDetailsJob = inngest.createFunction(

--- a/lib/jobs/relationship-network.ts
+++ b/lib/jobs/relationship-network.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { mapRelationshipNetwork } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
@@ -16,14 +17,7 @@ interface RelationshipNetworkEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[RelationshipNetworkJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'RelationshipNetworkJob');
 }
 
 export const processRelationshipNetworkJob = inngest.createFunction(

--- a/lib/jobs/similar-cases.ts
+++ b/lib/jobs/similar-cases.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { findSimilarCases } from '@/lib/cold-case-analyzer';
 
 interface SimilarCasesEventData {
@@ -15,14 +16,7 @@ interface SimilarCasesEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[SimilarCasesJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'SimilarCasesJob');
 }
 
 export const processSimilarCasesJob = inngest.createFunction(

--- a/lib/jobs/timeline-analysis.ts
+++ b/lib/jobs/timeline-analysis.ts
@@ -7,6 +7,7 @@
 
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import {
   analyzeCaseDocuments,
   detectTimeConflicts,
@@ -21,14 +22,7 @@ interface TimelineAnalysisEventData {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[TimelineAnalysisJob] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'TimelineAnalysisJob');
 }
 
 export const processTimelineAnalysisJob = inngest.createFunction(

--- a/lib/jobs/victim-timeline.ts
+++ b/lib/jobs/victim-timeline.ts
@@ -1,5 +1,6 @@
 import { inngest } from '@/lib/inngest-client';
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { generateComprehensiveVictimTimeline } from '@/lib/victim-timeline';
 
 interface VictimTimelineEventData {
@@ -19,18 +20,8 @@ interface VictimTimelineEventData {
   requestedAt: string;
 }
 
-async function updateProcessingJob(
-  jobId: string,
-  updates: Record<string, any>
-) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[VictimTimelineJob] Failed to update job', jobId, error);
-  }
+async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
+  await updateProcessingJobRecord(jobId, updates, 'VictimTimelineJob');
 }
 
 export const processVictimTimelineJob = inngest.createFunction(

--- a/lib/update-processing-job.ts
+++ b/lib/update-processing-job.ts
@@ -1,0 +1,28 @@
+import { supabaseServer } from '@/lib/supabase-server';
+
+type ProcessingJobUpdates = Record<string, any>;
+
+export async function updateProcessingJob(
+  jobId: string,
+  updates: ProcessingJobUpdates,
+  context: string = 'ProcessingJob'
+) {
+  const { progress_percentage, ...sanitizedUpdates } = updates;
+
+  if (progress_percentage !== undefined) {
+    // progress_percentage is a generated column; ignore explicit updates
+  }
+
+  if (Object.keys(sanitizedUpdates).length === 0) {
+    return;
+  }
+
+  const { error } = await supabaseServer
+    .from('processing_jobs')
+    .update(sanitizedUpdates)
+    .eq('id', jobId);
+
+  if (error) {
+    console.error(`[${context}] Failed to update job ${jobId}`, error);
+  }
+}

--- a/lib/workflows/behavioral-patterns.ts
+++ b/lib/workflows/behavioral-patterns.ts
@@ -8,23 +8,13 @@
  */
 
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { analyzeBehavioralPatterns } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
 interface BehavioralPatternsParams {
   jobId: string;
   caseId: string;
-}
-
-async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[BehavioralPatternsWorkflow] Failed to update job', jobId, error);
-  }
 }
 
 export async function processBehavioralPatterns(params: BehavioralPatternsParams) {
@@ -41,12 +31,12 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
   try {
     async function initializeJob() {
       'use step';
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         status: 'running',
         total_units: totalUnits,
         started_at: new Date().toISOString(),
         metadata: initialMetadata,
-      });
+      }, 'BehavioralPatternsWorkflow');
     }
     await initializeJob();
 
@@ -63,9 +53,9 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
 
       console.log(`[Behavioral Patterns] Found ${documents?.length || 0} documents`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 1,
-      });
+      }, 'BehavioralPatternsWorkflow');
 
       return { documents: documents || [] };
     }
@@ -91,9 +81,9 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
 
       console.log(`[Behavioral Patterns] Found ${interviews.length} interview transcripts`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 2,
-      });
+      }, 'BehavioralPatternsWorkflow');
 
       return { interviews };
     }
@@ -108,9 +98,9 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
       console.log('[Behavioral Patterns] Analyzing behavioral patterns...');
       const patterns = await analyzeBehavioralPatterns(interviews);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 3,
-      });
+      }, 'BehavioralPatternsWorkflow');
 
       return patterns;
     }
@@ -135,7 +125,7 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
       }
 
       // Mark job as completed
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         status: 'completed',
         completed_units: totalUnits,
         completed_at: new Date().toISOString(),
@@ -149,7 +139,7 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
             interviewsAnalyzed: interviews.length,
           },
         },
-      });
+      }, 'BehavioralPatternsWorkflow');
     }
     await saveResults();
 
@@ -158,7 +148,7 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
       jobId,
     };
   } catch (error: any) {
-    await updateProcessingJob(jobId, {
+    await updateProcessingJobRecord(jobId, {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
@@ -167,7 +157,7 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
         ...initialMetadata,
         error: error?.message || 'Behavioral pattern analysis failed',
       },
-    });
+    }, 'BehavioralPatternsWorkflow');
 
     console.error('[BehavioralPatternsWorkflow] Failed to process behavioral patterns:', error);
     throw error;

--- a/lib/workflows/forensic-retesting.ts
+++ b/lib/workflows/forensic-retesting.ts
@@ -8,22 +8,12 @@
  */
 
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { recommendForensicRetesting } from '@/lib/cold-case-analyzer';
 
 interface ForensicRetestingParams {
   jobId: string;
   caseId: string;
-}
-
-async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[ForensicRetestingWorkflow] Failed to update job', jobId, error);
-  }
 }
 
 /**
@@ -49,12 +39,12 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
     // Step 1: Initialize job
     async function initializeJob() {
       'use step';
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         status: 'running',
         total_units: totalUnits,
         started_at: new Date().toISOString(),
         metadata: initialMetadata,
-      });
+      }, 'ForensicRetestingWorkflow');
     }
     await initializeJob();
 
@@ -73,10 +63,9 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
 
       console.log(`[Forensic Retesting] Case: ${caseData.title || caseData.name || 'Unnamed'}`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
-      });
+      }, 'ForensicRetestingWorkflow');
 
       return { caseData };
     }
@@ -105,10 +94,9 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
 
       console.log(`[Forensic Retesting] Found ${evidenceItems.length} evidence items`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
-      });
+      }, 'ForensicRetestingWorkflow');
 
       return { evidenceItems };
     }
@@ -125,10 +113,9 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
       const highPriority = recommendations.filter((r) => r.priority === 'high' || r.priority === 'critical').length;
       console.log(`[Forensic Retesting] Generated ${recommendations.length} recommendations (${highPriority} high priority)`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
-      });
+      }, 'ForensicRetestingWorkflow');
 
       return recommendations;
     }
@@ -154,20 +141,21 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
       }
 
       // Mark job as completed
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
           summary: {
             totalRecommendations: recommendations.length,
             highPriority: recommendations.filter((r) => r.priority === 'high' || r.priority === 'critical').length,
-            modernTechniques: recommendations.map((r) => r.recommendedTest).filter((v, i, a) => a.indexOf(v) === i).length,
+            modernTechniques: recommendations
+              .map((r) => r.recommendedTest)
+              .filter((v, i, a) => a.indexOf(v) === i).length,
           },
         },
-      });
+      }, 'ForensicRetestingWorkflow');
     }
     await saveResults();
 
@@ -176,17 +164,16 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
       jobId,
     };
   } catch (error: any) {
-    await updateProcessingJob(jobId, {
+    await updateProcessingJobRecord(jobId, {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,
         error: error?.message || 'Forensic retesting analysis failed',
       },
-    });
+    }, 'ForensicRetestingWorkflow');
 
     console.error('[ForensicRetestingWorkflow] Failed to process forensic retesting:', error);
     throw error;

--- a/lib/workflows/interrogation-questions.ts
+++ b/lib/workflows/interrogation-questions.ts
@@ -8,23 +8,13 @@
  */
 
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { generateInterrogationQuestions } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
 interface InterrogationQuestionsParams {
   jobId: string;
   caseId: string;
-}
-
-async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[InterrogationQuestionsWorkflow] Failed to update job', jobId, error);
-  }
 }
 
 /**
@@ -50,12 +40,12 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
     // Step 1: Initialize job
     async function initializeJob() {
       'use step';
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         status: 'running',
         total_units: totalUnits,
         started_at: new Date().toISOString(),
         metadata: initialMetadata,
-      });
+      }, 'InterrogationQuestionsWorkflow');
     }
     await initializeJob();
 
@@ -80,10 +70,9 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
 
       console.log(`[Interrogation Questions] Found: ${suspects?.length || 0} suspects, ${witnesses?.length || 0} witnesses, ${documents?.length || 0} documents`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
-      });
+      }, 'InterrogationQuestionsWorkflow');
 
       return { suspects: suspects || [], witnesses: witnesses || [], documents: documents || [] };
     }
@@ -115,10 +104,9 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
 
       console.log(`[Interrogation Questions] Extracted ${interviews.length} interviews`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
-      });
+      }, 'InterrogationQuestionsWorkflow');
 
       return { evidenceGaps, interviews };
     }
@@ -143,10 +131,9 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
       const totalQuestions = questionSets.reduce((sum, qs) => sum + qs.questions.length, 0);
       console.log(`[Interrogation Questions] Generated ${totalQuestions} questions for ${questionSets.length} persons`);
 
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
-      });
+      }, 'InterrogationQuestionsWorkflow');
 
       return { questionSets, personsList };
     }
@@ -172,10 +159,9 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
       }
 
       // Mark job as completed
-      await updateProcessingJob(jobId, {
+      await updateProcessingJobRecord(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -185,7 +171,7 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
             personsToReInterview: personsList.length,
           },
         },
-      });
+      }, 'InterrogationQuestionsWorkflow');
     }
     await saveResults();
 
@@ -194,17 +180,16 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
       jobId,
     };
   } catch (error: any) {
-    await updateProcessingJob(jobId, {
+    await updateProcessingJobRecord(jobId, {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,
         error: error?.message || 'Interrogation question generation failed',
       },
-    });
+    }, 'InterrogationQuestionsWorkflow');
 
     console.error('[InterrogationQuestionsWorkflow] Failed to generate interrogation questions:', error);
     throw error;

--- a/lib/workflows/overlooked-details.ts
+++ b/lib/workflows/overlooked-details.ts
@@ -8,6 +8,7 @@
  */
 
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { findOverlookedDetails } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
@@ -17,14 +18,7 @@ interface OverlookedDetailsParams {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[OverlookedDetailsWorkflow] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'OverlookedDetailsWorkflow');
 }
 
 /**

--- a/lib/workflows/relationship-network.ts
+++ b/lib/workflows/relationship-network.ts
@@ -8,6 +8,7 @@
  */
 
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { mapRelationshipNetwork } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 
@@ -17,14 +18,7 @@ interface RelationshipNetworkParams {
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[RelationshipNetworkWorkflow] Failed to update job', jobId, error);
-  }
+  await updateProcessingJobRecord(jobId, updates, 'RelationshipNetworkWorkflow');
 }
 
 /**

--- a/lib/workflows/victim-timeline.ts
+++ b/lib/workflows/victim-timeline.ts
@@ -8,6 +8,7 @@
  */
 
 import { supabaseServer } from '@/lib/supabase-server';
+import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { generateComprehensiveVictimTimeline } from '@/lib/victim-timeline';
 
 interface VictimTimelineParams {
@@ -27,18 +28,8 @@ interface VictimTimelineParams {
   requestedAt: string;
 }
 
-async function updateProcessingJob(
-  jobId: string,
-  updates: Record<string, any>
-) {
-  const { error } = await supabaseServer
-    .from('processing_jobs')
-    .update(updates)
-    .eq('id', jobId);
-
-  if (error) {
-    console.error('[VictimTimelineWorkflow] Failed to update job', jobId, error);
-  }
+async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
+  await updateProcessingJobRecord(jobId, updates, 'VictimTimelineWorkflow');
 }
 
 export async function processVictimTimeline(params: VictimTimelineParams) {


### PR DESCRIPTION
## Summary
- add a shared Supabase helper that strips writes to the generated `progress_percentage` column before updating `processing_jobs`
- update every workflow and inngest job to use the helper so progress is derived from unit counts without triggering database errors
- remove redundant manual progress writes from the timeline and behavioral workflows now that the percentage is computed automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911711421388325ba79c2906216134a)