### PR TITLE
Fix: Remove progress_percentage updates (generated column)

### DIFF
--- a/lib/workflows/behavioral-patterns.ts
+++ b/lib/workflows/behavioral-patterns.ts
@@ -162,6 +162,7 @@ export async function processBehavioralPatterns(params: BehavioralPatternsParams
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/deep-analysis.ts
+++ b/lib/workflows/deep-analysis.ts
@@ -97,7 +97,7 @@ export async function processDeepAnalysis(params: DeepAnalysisParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { caseData, documents: documents || [], suspects: suspects || [], evidence: evidence || [] };
@@ -136,7 +136,7 @@ export async function processDeepAnalysis(params: DeepAnalysisParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { extractionResults, queuedForReview };
@@ -174,7 +174,7 @@ export async function processDeepAnalysis(params: DeepAnalysisParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return analysis;
@@ -203,7 +203,7 @@ export async function processDeepAnalysis(params: DeepAnalysisParams) {
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -230,7 +230,7 @@ export async function processDeepAnalysis(params: DeepAnalysisParams) {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/evidence-gaps.ts
+++ b/lib/workflows/evidence-gaps.ts
@@ -161,6 +161,7 @@ export async function processEvidenceGaps(params: EvidenceGapsParams) {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/forensic-retesting.ts
+++ b/lib/workflows/forensic-retesting.ts
@@ -75,7 +75,7 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { caseData };
@@ -107,7 +107,7 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { evidenceItems };
@@ -127,7 +127,7 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return recommendations;
@@ -157,7 +157,7 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -180,7 +180,7 @@ export async function processForensicRetesting(params: ForensicRetestingParams) 
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/interrogation-questions.ts
+++ b/lib/workflows/interrogation-questions.ts
@@ -82,7 +82,7 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { suspects: suspects || [], witnesses: witnesses || [], documents: documents || [] };
@@ -117,7 +117,7 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { evidenceGaps, interviews };
@@ -145,7 +145,7 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { questionSets, personsList };
@@ -175,7 +175,7 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -198,7 +198,7 @@ export async function processInterrogationQuestions(params: InterrogationQuestio
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/overlooked-details.ts
+++ b/lib/workflows/overlooked-details.ts
@@ -79,7 +79,7 @@ export async function processOverlookedDetails(params: OverlookedDetailsParams) 
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { documents };
@@ -108,7 +108,7 @@ export async function processOverlookedDetails(params: OverlookedDetailsParams) 
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { documentContents };
@@ -130,7 +130,7 @@ export async function processOverlookedDetails(params: OverlookedDetailsParams) 
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return details;
@@ -160,7 +160,7 @@ export async function processOverlookedDetails(params: OverlookedDetailsParams) 
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -183,7 +183,7 @@ export async function processOverlookedDetails(params: OverlookedDetailsParams) 
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/relationship-network.ts
+++ b/lib/workflows/relationship-network.ts
@@ -82,7 +82,7 @@ export async function processRelationshipNetwork(params: RelationshipNetworkPara
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { suspects: suspects || [], witnesses: witnesses || [], documents: documents || [] };
@@ -106,7 +106,7 @@ export async function processRelationshipNetwork(params: RelationshipNetworkPara
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { documentTexts };
@@ -128,7 +128,7 @@ export async function processRelationshipNetwork(params: RelationshipNetworkPara
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return network;
@@ -158,7 +158,7 @@ export async function processRelationshipNetwork(params: RelationshipNetworkPara
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -181,7 +181,7 @@ export async function processRelationshipNetwork(params: RelationshipNetworkPara
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/similar-cases.ts
+++ b/lib/workflows/similar-cases.ts
@@ -75,7 +75,7 @@ export async function processSimilarCases(params: SimilarCasesParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { currentCase };
@@ -99,7 +99,7 @@ export async function processSimilarCases(params: SimilarCasesParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { otherCases: otherCases || [] };
@@ -135,7 +135,7 @@ export async function processSimilarCases(params: SimilarCasesParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return similarCases;
@@ -165,7 +165,7 @@ export async function processSimilarCases(params: SimilarCasesParams) {
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -188,7 +188,7 @@ export async function processSimilarCases(params: SimilarCasesParams) {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/timeline-analysis.ts
+++ b/lib/workflows/timeline-analysis.ts
@@ -84,7 +84,7 @@ export async function processTimelineAnalysis(params: TimelineAnalysisParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return documents;
@@ -117,7 +117,7 @@ export async function processTimelineAnalysis(params: TimelineAnalysisParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { extractionResults, queuedForReview };
@@ -158,7 +158,7 @@ export async function processTimelineAnalysis(params: TimelineAnalysisParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return analysis;
@@ -216,7 +216,7 @@ export async function processTimelineAnalysis(params: TimelineAnalysisParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 4,
-        progress_percentage: Math.round((4 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
     }
     await saveTimelineEvents();
@@ -296,7 +296,7 @@ export async function processTimelineAnalysis(params: TimelineAnalysisParams) {
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -321,7 +321,7 @@ export async function processTimelineAnalysis(params: TimelineAnalysisParams) {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,

--- a/lib/workflows/victim-timeline.ts
+++ b/lib/workflows/victim-timeline.ts
@@ -89,7 +89,7 @@ export async function processVictimTimeline(params: VictimTimelineParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 1,
-        progress_percentage: Math.round((1 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return { documents: documents || [], files: files || [] };
@@ -125,7 +125,7 @@ export async function processVictimTimeline(params: VictimTimelineParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 2,
-        progress_percentage: Math.round((2 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
 
       return result;
@@ -201,7 +201,7 @@ export async function processVictimTimeline(params: VictimTimelineParams) {
 
       await updateProcessingJob(jobId, {
         completed_units: 3,
-        progress_percentage: Math.round((3 / totalUnits) * 100),
+        // progress_percentage auto-calculates from completed_units/total_units
       });
     }
     await persistResults();
@@ -211,7 +211,7 @@ export async function processVictimTimeline(params: VictimTimelineParams) {
       await updateProcessingJob(jobId, {
         status: 'completed',
         completed_units: totalUnits,
-        progress_percentage: 100,
+        // progress_percentage auto-calculates from completed_units/total_units
         completed_at: new Date().toISOString(),
         metadata: {
           ...initialMetadata,
@@ -235,7 +235,7 @@ export async function processVictimTimeline(params: VictimTimelineParams) {
       status: 'failed',
       completed_units: totalUnits,
       failed_units: 1,
-      progress_percentage: 100,
+      // progress_percentage auto-calculates from completed_units/total_units
       completed_at: new Date().toISOString(),
       metadata: {
         ...initialMetadata,


### PR DESCRIPTION
CRITICAL FIX: Workflows were failing because progress_percentage is a GENERATED database column that auto-calculates from completed_units/total_units.

Error: 'column "progress_percentage" can only be updated to DEFAULT'

Changes:
- Removed all 43 manual progress_percentage updates across 10 workflow files
- Database now auto-calculates: (completed_units / total_units) * 100
- Workflows will now execute without database conflicts

This should fix the job execution failures!