### PR TITLE
Use unstable_after to keep analysis workflows running

### DIFF
--- a/app/api/cases/[caseId]/analyze/route.ts
+++ b/app/api/cases/[caseId]/analyze/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { hasSupabaseServiceConfig } from '@/lib/environment';
 import { processTimelineAnalysis } from '@/lib/workflows/timeline-analysis';
@@ -490,13 +490,17 @@ export async function POST(
 
     createdJobId = job.id;
 
-    // Trigger workflow in background (fire and forget)
-    processTimelineAnalysis({
-      jobId: job.id,
-      caseId,
-    }).catch((error) => {
-      console.error('[Timeline Analysis API] Workflow failed:', error);
-      // Workflow will update job status to 'failed' internally
+    // Trigger workflow in background after response completes
+    unstable_after(async () => {
+      try {
+        await processTimelineAnalysis({
+          jobId: job.id,
+          caseId,
+        });
+      } catch (error) {
+        console.error('[Timeline Analysis API] Workflow failed:', error);
+        // Workflow will update job status to 'failed' internally
+      }
     });
 
     return withCors(

--- a/app/api/cases/[caseId]/deep-analysis/route.ts
+++ b/app/api/cases/[caseId]/deep-analysis/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { hasSupabaseServiceConfig } from '@/lib/environment';
 import { processDeepAnalysis } from '@/lib/workflows/deep-analysis';
@@ -148,13 +148,17 @@ export async function POST(
       );
     }
 
-    // Trigger workflow in background (fire and forget)
-    processDeepAnalysis({
-      jobId: job.id,
-      caseId,
-    }).catch((error) => {
-      console.error('[Deep Analysis API] Workflow failed:', error);
-      // Workflow will update job status to 'failed' internally
+    // Trigger workflow in background after response flushes
+    unstable_after(async () => {
+      try {
+        await processDeepAnalysis({
+          jobId: job.id,
+          caseId,
+        });
+      } catch (error) {
+        console.error('[Deep Analysis API] Workflow failed:', error);
+        // Workflow will update job status to 'failed' internally
+      }
     });
 
     // Return immediately with job ID

--- a/app/api/cases/[caseId]/forensic-retesting/route.ts
+++ b/app/api/cases/[caseId]/forensic-retesting/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processForensicRetesting } from '@/lib/workflows/forensic-retesting';
 
@@ -88,13 +88,17 @@ export async function POST(
       );
     }
 
-    // Trigger workflow in background (fire and forget)
-    processForensicRetesting({
-      jobId: job.id,
-      caseId,
-    }).catch((error) => {
-      console.error('[Forensic Retesting API] Workflow failed:', error);
-      // Workflow will update job status to 'failed' internally
+    // Trigger workflow in background after the response completes
+    unstable_after(async () => {
+      try {
+        await processForensicRetesting({
+          jobId: job.id,
+          caseId,
+        });
+      } catch (error) {
+        console.error('[Forensic Retesting API] Workflow failed:', error);
+        // Workflow will update job status to 'failed' internally
+      }
     });
 
     return withCors(

--- a/app/api/cases/[caseId]/interrogation-questions/route.ts
+++ b/app/api/cases/[caseId]/interrogation-questions/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processInterrogationQuestions } from '@/lib/workflows/interrogation-questions';
 
@@ -88,13 +88,17 @@ export async function POST(
       );
     }
 
-    // Trigger workflow in background (fire and forget)
-    processInterrogationQuestions({
-      jobId: job.id,
-      caseId,
-    }).catch((error) => {
-      console.error('[Interrogation Questions API] Workflow failed:', error);
-      // Workflow will update job status to 'failed' internally
+    // Trigger workflow in background after the response finishes
+    unstable_after(async () => {
+      try {
+        await processInterrogationQuestions({
+          jobId: job.id,
+          caseId,
+        });
+      } catch (error) {
+        console.error('[Interrogation Questions API] Workflow failed:', error);
+        // Workflow will update job status to 'failed' internally
+      }
     });
 
     return withCors(

--- a/app/api/cases/[caseId]/relationship-network/route.ts
+++ b/app/api/cases/[caseId]/relationship-network/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processRelationshipNetwork } from '@/lib/workflows/relationship-network';
 
@@ -88,13 +88,17 @@ export async function POST(
       );
     }
 
-    // Trigger workflow in background (fire and forget)
-    processRelationshipNetwork({
-      jobId: job.id,
-      caseId,
-    }).catch((error) => {
-      console.error('[Relationship Network API] Workflow failed:', error);
-      // Workflow will update job status to 'failed' internally
+    // Trigger workflow in background after the response completes
+    unstable_after(async () => {
+      try {
+        await processRelationshipNetwork({
+          jobId: job.id,
+          caseId,
+        });
+      } catch (error) {
+        console.error('[Relationship Network API] Workflow failed:', error);
+        // Workflow will update job status to 'failed' internally
+      }
     });
 
     return withCors(


### PR DESCRIPTION
## Summary
- schedule each asynchronous analysis workflow with `unstable_after` so execution continues after the API response returns
- update all case analysis endpoints to import `unstable_after` and wrap workflow invocations in try/catch logging

## Testing
- lint (fails: interactive ESLint setup prompt)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117eab049883258e9a28652f63136e)