### PR TITLE
Remove stuck processing jobs from database

### DIFF
--- a/STUCK_JOBS_CLEANUP.md
+++ b/STUCK_JOBS_CLEANUP.md
@@ -1,0 +1,316 @@
+# Stuck Jobs Cleanup System
+
+This document explains how to identify and clean up processing jobs that are stuck in "running" status.
+
+## Overview
+
+Processing jobs can sometimes get stuck in a "running" status indefinitely due to various issues:
+- Worker process crashes
+- Network timeouts
+- Inngest workflow failures
+- Database connection issues
+
+This cleanup system provides tools to identify and handle these stuck jobs.
+
+## What is a "Stuck Job"?
+
+A job is considered stuck if:
+- Status is `running`
+- The `updated_at` timestamp is older than a configurable threshold (default: 2 hours)
+
+## Cleanup Methods
+
+There are two ways to handle stuck jobs:
+
+### 1. Mark as Failed (Recommended)
+This approach marks stuck jobs with `status: 'failed'` and adds an error message explaining they were automatically cleaned up. The job data is preserved for debugging.
+
+### 2. Delete Permanently
+This approach completely removes stuck jobs and their associated document chunks from the database. Use with caution as this cannot be undone.
+
+## Usage
+
+### Option 1: NPM Scripts (Recommended)
+
+```bash
+# Dry run - find stuck jobs without modifying them
+npm run cleanup:stuck-jobs:dry-run
+
+# Mark stuck jobs as failed (default behavior)
+npm run cleanup:stuck-jobs
+
+# Delete stuck jobs permanently
+npm run cleanup:stuck-jobs:delete
+```
+
+### Option 2: Direct Script Execution
+
+```bash
+# Dry run
+npx tsx lib/cleanup-stuck-jobs.ts --dry-run
+
+# Mark as failed (default)
+npx tsx lib/cleanup-stuck-jobs.ts
+
+# Delete permanently
+npx tsx lib/cleanup-stuck-jobs.ts --delete
+
+# Use custom threshold (e.g., 4 hours)
+npx tsx lib/cleanup-stuck-jobs.ts --threshold 4
+
+# Combine options
+npx tsx lib/cleanup-stuck-jobs.ts --delete --threshold 6
+```
+
+### Option 3: API Endpoints
+
+#### Find Stuck Jobs (GET)
+
+```bash
+# Default 2-hour threshold
+curl http://localhost:3000/api/processing-jobs/cleanup
+
+# Custom threshold
+curl http://localhost:3000/api/processing-jobs/cleanup?threshold=4
+```
+
+Response:
+```json
+{
+  "stuckJobCount": 3,
+  "stuckJobs": [
+    {
+      "id": "job-uuid-1",
+      "caseId": "case-uuid",
+      "jobType": "document_extraction",
+      "status": "running",
+      "totalUnits": 100,
+      "completedUnits": 45,
+      "progressPercentage": 45,
+      "startedAt": "2024-01-01T10:00:00Z"
+    }
+  ]
+}
+```
+
+#### Clean Up Stuck Jobs (POST)
+
+```bash
+# Mark as failed (default)
+curl -X POST http://localhost:3000/api/processing-jobs/cleanup
+
+# Mark as failed with custom threshold
+curl -X POST "http://localhost:3000/api/processing-jobs/cleanup?action=mark-failed&threshold=4"
+
+# Delete permanently
+curl -X POST "http://localhost:3000/api/processing-jobs/cleanup?action=delete&threshold=2"
+```
+
+Response:
+```json
+{
+  "message": "Marked 3 stuck jobs as failed",
+  "cleanedJobCount": 3,
+  "cleanedJobIds": [
+    "job-uuid-1",
+    "job-uuid-2",
+    "job-uuid-3"
+  ]
+}
+```
+
+### Option 4: Programmatic Usage
+
+```typescript
+import {
+  findStuckJobs,
+  cleanupStuckJobs,
+  deleteStuckJobs
+} from '@/lib/progress-tracker';
+
+// Find stuck jobs (read-only)
+const stuckJobs = await findStuckJobs(2); // 2 hours threshold
+console.log(`Found ${stuckJobs.length} stuck jobs`);
+
+// Mark stuck jobs as failed
+const cleanupResult = await cleanupStuckJobs(2);
+console.log(`Cleaned up ${cleanupResult.cleanedJobCount} jobs`);
+
+// Delete stuck jobs permanently
+const deleteResult = await deleteStuckJobs(2);
+console.log(`Deleted ${deleteResult.deletedJobCount} jobs`);
+```
+
+## Parameters
+
+### Threshold Hours
+- **Description**: Number of hours since last update to consider a job stuck
+- **Default**: 2 hours
+- **Range**: 1-24 hours
+- **Recommendation**:
+  - Use 1-2 hours for quick cleanup
+  - Use 4-6 hours for conservative cleanup
+  - Use 12-24 hours for very conservative cleanup
+
+### Action
+- **mark-failed**: Set job status to 'failed' and add error summary (recommended)
+- **delete**: Permanently remove job and associated chunks (use with caution)
+
+## What Gets Modified
+
+### When Marking as Failed
+
+**Processing Jobs Table:**
+- `status` → `'failed'`
+- `completed_at` → current timestamp
+- `error_summary` → includes cleanup message and timestamp
+
+**Document Chunks Table:**
+- Chunks with `processing_status` of `'pending'` or `'processing'`:
+  - `processing_status` → `'failed'`
+  - `error_log` → "Job was stuck and automatically cleaned up"
+  - `processed_at` → current timestamp
+
+### When Deleting
+
+**Document Chunks Table:**
+- All chunks associated with the job are deleted
+
+**Processing Jobs Table:**
+- Job record is deleted
+
+## Scheduling Cleanup
+
+### Option 1: Cron Job (Linux/Mac)
+
+```bash
+# Add to crontab (run every hour)
+0 * * * * cd /path/to/project && npm run cleanup:stuck-jobs >> /var/log/stuck-jobs-cleanup.log 2>&1
+```
+
+### Option 2: Vercel Cron (Recommended for Production)
+
+Add to `vercel.json`:
+
+```json
+{
+  "crons": [
+    {
+      "path": "/api/processing-jobs/cleanup?action=mark-failed&threshold=2",
+      "schedule": "0 * * * *"
+    }
+  ]
+}
+```
+
+### Option 3: GitHub Actions
+
+Create `.github/workflows/cleanup-stuck-jobs.yml`:
+
+```yaml
+name: Cleanup Stuck Jobs
+on:
+  schedule:
+    - cron: '0 * * * *'  # Every hour
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: npm ci
+      - run: npm run cleanup:stuck-jobs
+        env:
+          # Add your Supabase credentials
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+```
+
+## Monitoring
+
+### Check for Stuck Jobs
+
+```bash
+# Regular check
+npm run cleanup:stuck-jobs:dry-run
+
+# Custom threshold
+npx tsx lib/cleanup-stuck-jobs.ts --dry-run --threshold 4
+```
+
+### View Cleanup Results
+
+The cleanup script provides detailed output:
+
+```
+============================================================
+STUCK JOBS CLEANUP SCRIPT
+============================================================
+Threshold: 2 hours
+Mode: MARK AS FAILED
+============================================================
+
+Marking stuck jobs as failed...
+✓ Successfully marked 3 stuck jobs as failed
+
+Cleaned job IDs:
+  1. abc123...
+  2. def456...
+  3. ghi789...
+
+============================================================
+CLEANUP COMPLETE
+============================================================
+```
+
+## Best Practices
+
+1. **Always run dry-run first** before cleanup to preview what will be affected
+2. **Use "mark as failed" instead of "delete"** to preserve data for debugging
+3. **Monitor stuck jobs regularly** to identify systemic issues
+4. **Adjust threshold based on job types**:
+   - Document extraction: 1-2 hours
+   - AI analysis: 2-4 hours
+   - Embedding generation: 2-4 hours
+5. **Review cleanup logs** to identify patterns in stuck jobs
+6. **Fix root causes** instead of just cleaning up symptoms
+
+## Troubleshooting
+
+### No Jobs Found
+If no stuck jobs are found but you believe some exist:
+- Check the threshold is appropriate
+- Verify jobs are actually in "running" status
+- Check database connectivity
+
+### Cleanup Fails
+If cleanup operations fail:
+- Check database permissions
+- Verify Supabase connection
+- Review error logs
+- Try increasing timeout settings
+
+### Jobs Keep Getting Stuck
+If jobs consistently get stuck:
+- Review Inngest workflow logs
+- Check worker process health
+- Verify API timeouts are adequate
+- Monitor database performance
+- Review error patterns in `error_summary`
+
+## Related Files
+
+- **Functions**: `/lib/progress-tracker.ts`
+- **API Endpoint**: `/app/api/processing-jobs/cleanup/route.ts`
+- **CLI Script**: `/lib/cleanup-stuck-jobs.ts`
+- **Database Schema**: `/supabase-document-chunking-migration-clean.sql`
+
+## Support
+
+For issues or questions about stuck jobs cleanup:
+1. Check the job's `error_summary` field for details
+2. Review Inngest workflow logs
+3. Check application logs for errors
+4. Create an issue with job details and error messages

--- a/app/api/processing-jobs/cleanup/route.ts
+++ b/app/api/processing-jobs/cleanup/route.ts
@@ -1,0 +1,91 @@
+/**
+ * API endpoint to clean up stuck processing jobs
+ *
+ * POST /api/processing-jobs/cleanup
+ *
+ * Query parameters:
+ * - action: 'mark-failed' (default) or 'delete' - determines cleanup behavior
+ * - threshold: number of hours to consider a job stuck (default: 2)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { cleanupStuckJobs, deleteStuckJobs, findStuckJobs } from '@/lib/progress-tracker';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const action = searchParams.get('action') || 'mark-failed';
+    const thresholdHours = parseInt(searchParams.get('threshold') || '2', 10);
+
+    if (thresholdHours < 1 || thresholdHours > 24) {
+      return NextResponse.json(
+        { error: 'Threshold must be between 1 and 24 hours' },
+        { status: 400 }
+      );
+    }
+
+    if (action === 'delete') {
+      // Permanently delete stuck jobs
+      const result = await deleteStuckJobs(thresholdHours);
+      return NextResponse.json({
+        message: `Deleted ${result.deletedJobCount} stuck jobs`,
+        deletedJobCount: result.deletedJobCount,
+        deletedJobIds: result.deletedJobIds,
+      });
+    } else if (action === 'mark-failed') {
+      // Mark stuck jobs as failed
+      const result = await cleanupStuckJobs(thresholdHours);
+      return NextResponse.json({
+        message: `Marked ${result.cleanedJobCount} stuck jobs as failed`,
+        cleanedJobCount: result.cleanedJobCount,
+        cleanedJobIds: result.cleanedJobIds,
+      });
+    } else {
+      return NextResponse.json(
+        { error: 'Invalid action. Use "mark-failed" or "delete"' },
+        { status: 400 }
+      );
+    }
+  } catch (error) {
+    console.error('Error cleaning up stuck jobs:', error);
+    return NextResponse.json(
+      { error: 'Failed to clean up stuck jobs' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET endpoint to find stuck jobs without modifying them
+ *
+ * GET /api/processing-jobs/cleanup
+ *
+ * Query parameters:
+ * - threshold: number of hours to consider a job stuck (default: 2)
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const thresholdHours = parseInt(searchParams.get('threshold') || '2', 10);
+
+    if (thresholdHours < 1 || thresholdHours > 24) {
+      return NextResponse.json(
+        { error: 'Threshold must be between 1 and 24 hours' },
+        { status: 400 }
+      );
+    }
+
+    const stuckJobs = await findStuckJobs(thresholdHours);
+
+    return NextResponse.json({
+      stuckJobCount: stuckJobs.length,
+      stuckJobs,
+    });
+  } catch (error) {
+    console.error('Error finding stuck jobs:', error);
+    return NextResponse.json(
+      { error: 'Failed to find stuck jobs' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/cleanup-stuck-jobs.ts
+++ b/lib/cleanup-stuck-jobs.ts
@@ -1,0 +1,132 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Standalone script to clean up stuck processing jobs
+ *
+ * Usage:
+ *   npx ts-node lib/cleanup-stuck-jobs.ts [options]
+ *
+ * Options:
+ *   --delete              Delete stuck jobs instead of marking as failed
+ *   --threshold <hours>   Number of hours to consider a job stuck (default: 2)
+ *   --dry-run            Find stuck jobs without modifying them
+ *
+ * Examples:
+ *   # Mark stuck jobs as failed (default)
+ *   npx ts-node lib/cleanup-stuck-jobs.ts
+ *
+ *   # Delete stuck jobs permanently
+ *   npx ts-node lib/cleanup-stuck-jobs.ts --delete
+ *
+ *   # Use 4-hour threshold
+ *   npx ts-node lib/cleanup-stuck-jobs.ts --threshold 4
+ *
+ *   # Find stuck jobs without modifying them
+ *   npx ts-node lib/cleanup-stuck-jobs.ts --dry-run
+ */
+
+import { cleanupStuckJobs, deleteStuckJobs, findStuckJobs } from './progress-tracker';
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Parse command line arguments
+  const deleteMode = args.includes('--delete');
+  const dryRun = args.includes('--dry-run');
+
+  const thresholdIndex = args.indexOf('--threshold');
+  const threshold = thresholdIndex >= 0 && args[thresholdIndex + 1]
+    ? parseInt(args[thresholdIndex + 1], 10)
+    : 2;
+
+  if (isNaN(threshold) || threshold < 1 || threshold > 24) {
+    console.error('Error: Threshold must be between 1 and 24 hours');
+    process.exit(1);
+  }
+
+  console.log('='.repeat(60));
+  console.log('STUCK JOBS CLEANUP SCRIPT');
+  console.log('='.repeat(60));
+  console.log(`Threshold: ${threshold} hours`);
+  console.log(`Mode: ${dryRun ? 'DRY RUN (no changes)' : deleteMode ? 'DELETE' : 'MARK AS FAILED'}`);
+  console.log('='.repeat(60));
+  console.log();
+
+  try {
+    if (dryRun) {
+      // Find stuck jobs without modifying them
+      console.log('Searching for stuck jobs...');
+      const stuckJobs = await findStuckJobs(threshold);
+
+      if (stuckJobs.length === 0) {
+        console.log('✓ No stuck jobs found!');
+        console.log();
+        process.exit(0);
+      }
+
+      console.log(`Found ${stuckJobs.length} stuck jobs:\n`);
+      stuckJobs.forEach((job, index) => {
+        console.log(`${index + 1}. Job ID: ${job.id}`);
+        console.log(`   Type: ${job.jobType}`);
+        console.log(`   Case ID: ${job.caseId}`);
+        console.log(`   Progress: ${job.completedUnits}/${job.totalUnits} (${job.progressPercentage}%)`);
+        console.log(`   Started: ${job.startedAt || 'N/A'}`);
+        console.log();
+      });
+
+      console.log('='.repeat(60));
+      console.log('DRY RUN - No changes made');
+      console.log('Run without --dry-run to clean up these jobs');
+      console.log('='.repeat(60));
+    } else if (deleteMode) {
+      // Permanently delete stuck jobs
+      console.log('Deleting stuck jobs...');
+      const result = await deleteStuckJobs(threshold);
+
+      if (result.deletedJobCount === 0) {
+        console.log('✓ No stuck jobs found!');
+        console.log();
+        process.exit(0);
+      }
+
+      console.log(`✓ Successfully deleted ${result.deletedJobCount} stuck jobs`);
+      console.log();
+      console.log('Deleted job IDs:');
+      result.deletedJobIds.forEach((id, index) => {
+        console.log(`  ${index + 1}. ${id}`);
+      });
+      console.log();
+    } else {
+      // Mark stuck jobs as failed
+      console.log('Marking stuck jobs as failed...');
+      const result = await cleanupStuckJobs(threshold);
+
+      if (result.cleanedJobCount === 0) {
+        console.log('✓ No stuck jobs found!');
+        console.log();
+        process.exit(0);
+      }
+
+      console.log(`✓ Successfully marked ${result.cleanedJobCount} stuck jobs as failed`);
+      console.log();
+      console.log('Cleaned job IDs:');
+      result.cleanedJobIds.forEach((id, index) => {
+        console.log(`  ${index + 1}. ${id}`);
+      });
+      console.log();
+    }
+
+    console.log('='.repeat(60));
+    console.log('CLEANUP COMPLETE');
+    console.log('='.repeat(60));
+    process.exit(0);
+  } catch (error) {
+    console.error('ERROR:', error);
+    process.exit(1);
+  }
+}
+
+// Run the script
+if (require.main === module) {
+  main();
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "cleanup:stuck-jobs": "npx tsx lib/cleanup-stuck-jobs.ts",
+    "cleanup:stuck-jobs:delete": "npx tsx lib/cleanup-stuck-jobs.ts --delete",
+    "cleanup:stuck-jobs:dry-run": "npx tsx lib/cleanup-stuck-jobs.ts --dry-run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",


### PR DESCRIPTION
Implements a comprehensive system to identify and clean up processing jobs stuck in "running" status.

Features:
- Three utility functions in progress-tracker.ts:
  - findStuckJobs(): Find jobs stuck for more than threshold hours
  - cleanupStuckJobs(): Mark stuck jobs as failed with error summary
  - deleteStuckJobs(): Permanently delete stuck jobs and chunks

- API endpoint at /api/processing-jobs/cleanup:
  - GET: Find stuck jobs without modifying them
  - POST: Clean up stuck jobs (mark-failed or delete)
  - Configurable threshold (1-24 hours, default 2)

- CLI script (lib/cleanup-stuck-jobs.ts):
  - Supports --dry-run, --delete, and --threshold flags
  - Detailed output showing cleaned jobs
  - Can be run via npm scripts or directly

- NPM scripts for easy execution:
  - cleanup:stuck-jobs: Mark stuck jobs as failed
  - cleanup:stuck-jobs:delete: Delete stuck jobs permanently
  - cleanup:stuck-jobs:dry-run: Preview stuck jobs

- Comprehensive documentation (STUCK_JOBS_CLEANUP.md):
  - Usage examples for all methods
  - Scheduling options (cron, Vercel, GitHub Actions)
  - Best practices and troubleshooting

This addresses the issue of jobs that get stuck in processing indefinitely due to worker crashes, timeouts, or workflow failures.