### PR TITLE
Fix background workflow scheduling regression

### DIFF
--- a/app/api/cases/[caseId]/behavioral-patterns/route.ts
+++ b/app/api/cases/[caseId]/behavioral-patterns/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processBehavioralPatterns } from '@/lib/workflows/behavioral-patterns';
+import { runBackgroundTask } from '@/lib/background-tasks';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -89,17 +90,22 @@ export async function POST(
     }
 
     // Trigger workflow in background after the response is sent
-    unstable_after(async () => {
-      try {
+    runBackgroundTask(
+      async () => {
         await processBehavioralPatterns({
           jobId: job.id,
           caseId,
         });
-      } catch (error) {
-        console.error('[Behavioral Patterns API] Workflow failed:', error);
-        // Workflow will update job status to 'failed' internally
+      },
+      {
+        label: 'Behavioral Patterns API',
+        scheduler: unstable_after,
+        onError: (error) => {
+          console.error('[Behavioral Patterns API] Workflow failed:', error);
+          // Workflow will update job status to 'failed' internally
+        },
       }
-    });
+    );
 
     return withCors(
       NextResponse.json(

--- a/app/api/cases/[caseId]/forensic-retesting/route.ts
+++ b/app/api/cases/[caseId]/forensic-retesting/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processForensicRetesting } from '@/lib/workflows/forensic-retesting';
+import { runBackgroundTask } from '@/lib/background-tasks';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -89,17 +90,22 @@ export async function POST(
     }
 
     // Trigger workflow in background after the response completes
-    unstable_after(async () => {
-      try {
+    runBackgroundTask(
+      async () => {
         await processForensicRetesting({
           jobId: job.id,
           caseId,
         });
-      } catch (error) {
-        console.error('[Forensic Retesting API] Workflow failed:', error);
-        // Workflow will update job status to 'failed' internally
+      },
+      {
+        label: 'Forensic Retesting API',
+        scheduler: unstable_after,
+        onError: (error) => {
+          console.error('[Forensic Retesting API] Workflow failed:', error);
+          // Workflow will update job status to 'failed' internally
+        },
       }
-    });
+    );
 
     return withCors(
       NextResponse.json(

--- a/app/api/cases/[caseId]/interrogation-questions/route.ts
+++ b/app/api/cases/[caseId]/interrogation-questions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processInterrogationQuestions } from '@/lib/workflows/interrogation-questions';
+import { runBackgroundTask } from '@/lib/background-tasks';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -89,17 +90,22 @@ export async function POST(
     }
 
     // Trigger workflow in background after the response finishes
-    unstable_after(async () => {
-      try {
+    runBackgroundTask(
+      async () => {
         await processInterrogationQuestions({
           jobId: job.id,
           caseId,
         });
-      } catch (error) {
-        console.error('[Interrogation Questions API] Workflow failed:', error);
-        // Workflow will update job status to 'failed' internally
+      },
+      {
+        label: 'Interrogation Questions API',
+        scheduler: unstable_after,
+        onError: (error) => {
+          console.error('[Interrogation Questions API] Workflow failed:', error);
+          // Workflow will update job status to 'failed' internally
+        },
       }
-    });
+    );
 
     return withCors(
       NextResponse.json(

--- a/app/api/cases/[caseId]/overlooked-details/route.ts
+++ b/app/api/cases/[caseId]/overlooked-details/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processOverlookedDetails } from '@/lib/workflows/overlooked-details';
+import { runBackgroundTask } from '@/lib/background-tasks';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -89,17 +90,22 @@ export async function POST(
     }
 
     // Trigger workflow in background after response completes
-    unstable_after(async () => {
-      try {
+    runBackgroundTask(
+      async () => {
         await processOverlookedDetails({
           jobId: job.id,
           caseId,
         });
-      } catch (error) {
-        console.error('[Overlooked Details API] Workflow failed:', error);
-        // Workflow will update job status to 'failed' internally
+      },
+      {
+        label: 'Overlooked Details API',
+        scheduler: unstable_after,
+        onError: (error) => {
+          console.error('[Overlooked Details API] Workflow failed:', error);
+          // Workflow will update job status to 'failed' internally
+        },
       }
-    });
+    );
 
     return withCors(
       NextResponse.json(

--- a/app/api/cases/[caseId]/relationship-network/route.ts
+++ b/app/api/cases/[caseId]/relationship-network/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processRelationshipNetwork } from '@/lib/workflows/relationship-network';
+import { runBackgroundTask } from '@/lib/background-tasks';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -89,17 +90,22 @@ export async function POST(
     }
 
     // Trigger workflow in background after the response completes
-    unstable_after(async () => {
-      try {
+    runBackgroundTask(
+      async () => {
         await processRelationshipNetwork({
           jobId: job.id,
           caseId,
         });
-      } catch (error) {
-        console.error('[Relationship Network API] Workflow failed:', error);
-        // Workflow will update job status to 'failed' internally
+      },
+      {
+        label: 'Relationship Network API',
+        scheduler: unstable_after,
+        onError: (error) => {
+          console.error('[Relationship Network API] Workflow failed:', error);
+          // Workflow will update job status to 'failed' internally
+        },
       }
-    });
+    );
 
     return withCors(
       NextResponse.json(

--- a/app/api/cases/[caseId]/similar-cases/route.ts
+++ b/app/api/cases/[caseId]/similar-cases/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processSimilarCases } from '@/lib/workflows/similar-cases';
+import { runBackgroundTask } from '@/lib/background-tasks';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -89,17 +90,22 @@ export async function POST(
     }
 
     // Trigger workflow in background after the response completes
-    unstable_after(async () => {
-      try {
+    runBackgroundTask(
+      async () => {
         await processSimilarCases({
           jobId: job.id,
           caseId,
         });
-      } catch (error) {
-        console.error('[Similar Cases API] Workflow failed:', error);
-        // Workflow will update job status to 'failed' internally
+      },
+      {
+        label: 'Similar Cases API',
+        scheduler: unstable_after,
+        onError: (error) => {
+          console.error('[Similar Cases API] Workflow failed:', error);
+          // Workflow will update job status to 'failed' internally
+        },
       }
-    });
+    );
 
     return withCors(
       NextResponse.json(

--- a/lib/background-tasks.ts
+++ b/lib/background-tasks.ts
@@ -1,0 +1,58 @@
+interface BackgroundTaskOptions {
+  label?: string;
+  onError?: (error: unknown) => void;
+  scheduler?: (callback: () => void | Promise<void>) => void;
+}
+
+type BackgroundTask = () => void | Promise<void>;
+
+function logError(label: string, error: unknown) {
+  console.error(`[${label}] Background task failed:`, error);
+}
+
+export function runBackgroundTask(
+  task: BackgroundTask,
+  options: BackgroundTaskOptions = {}
+) {
+  const { label = 'BackgroundTask', onError, scheduler } = options;
+
+  const executeTask = async () => {
+    try {
+      await task();
+    } catch (error) {
+      if (onError) {
+        try {
+          onError(error);
+        } catch (handlerError) {
+          logError(label, handlerError);
+        }
+      } else {
+        logError(label, error);
+      }
+    }
+  };
+
+  const scheduleWithFallback = (reason?: string, error?: unknown) => {
+    if (reason) {
+      console.warn(
+        `[${label}] Falling back to setTimeout${reason ? ` (${reason})` : ''}.`,
+        error
+      );
+    }
+    setTimeout(() => {
+      void executeTask();
+    }, 0);
+  };
+
+  if (scheduler) {
+    try {
+      scheduler(executeTask);
+      return;
+    } catch (error) {
+      scheduleWithFallback('scheduler threw an error', error);
+      return;
+    }
+  }
+
+  scheduleWithFallback();
+}


### PR DESCRIPTION
## Summary
- update the background task helper to accept an injected scheduler and warn when falling back to setTimeout
- reintroduce `unstable_after` usage inside each case analysis API route and pass it into the helper so background workflows schedule correctly

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/v0-cracker/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691289604e3c8325b00313a100edae20)