### PR TITLE
Fix processing dashboard case id guard

### DIFF
--- a/app/api/cases/[caseId]/processing-jobs/route.ts
+++ b/app/api/cases/[caseId]/processing-jobs/route.ts
@@ -27,7 +27,7 @@ export async function GET(
     const activeOnly = searchParams.get('active') === 'true';
     const statusFilter = searchParams.get('status');
 
-    if (!caseId) {
+    if (!caseId || caseId === 'undefined') {
       return NextResponse.json(
         { error: 'Case ID is required' },
         { status: 400 }

--- a/components/ProcessingDashboard.tsx
+++ b/components/ProcessingDashboard.tsx
@@ -51,13 +51,28 @@ export default function ProcessingDashboard({
 
   // Fetch jobs and stats
   const fetchJobsAndStats = useCallback(async () => {
-    try {
-      const activeParam = filter === 'active' ? '?active=true' : '';
-      const statusParam = filter === 'completed' || filter === 'failed' ? `?status=${filter}` : '';
+    if (!caseId || caseId === 'undefined') {
+      setJobs([]);
+      setStats(null);
+      setLoading(false);
+      return;
+    }
 
-      const response = await fetch(
-        `/api/cases/${caseId}/processing-jobs${activeParam || statusParam}`
-      );
+    try {
+      const params = new URLSearchParams();
+
+      if (filter === 'active') {
+        params.set('active', 'true');
+      } else if (filter === 'completed' || filter === 'failed') {
+        params.set('status', filter);
+      }
+
+      const queryString = params.toString();
+      const url = `/api/cases/${caseId}/processing-jobs${
+        queryString ? `?${queryString}` : ''
+      }`;
+
+      const response = await fetch(url);
 
       if (!response.ok) {
         throw new Error('Failed to fetch processing jobs');


### PR DESCRIPTION
## Summary
- prevent the processing dashboard from querying the API when the case id is missing
- ensure filter query strings are built safely before fetching jobs
- return a 400 response from the processing jobs API when the case id param is not supplied

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/v0-cracker/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912abbc6c8083259c9a592accf503cf)