### PR TITLE
Fix analysis display and functionality issues

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,11 @@ const nextConfig = {
     // !! WARN !!
     ignoreBuildErrors: true,
   },
+  // Enable experimental features for Next.js 15/16
+  experimental: {
+    // Enable unstable_after API for background task execution
+    after: true,
+  },
   // Turbopack configuration (Next.js 16+ uses Turbopack by default)
   turbopack: {
     // Empty config to acknowledge Turbopack usage and silence migration warnings


### PR DESCRIPTION
Fix for analysis workflows not running. The unstable_after API in Next.js 15/16 requires the experimental.after flag to be enabled in next.config.js.

Without this flag, background workflows triggered by analysis buttons were silently failing, causing no processing jobs to execute and no analysis results to display.

This change enables the experimental.after configuration which allows unstable_after to properly execute background tasks after API responses are sent.