### PR TITLE
Handle missing Supabase service role key for analysis workflows

### DIFF
--- a/app/api/cases/[caseId]/analysis/overview/route.ts
+++ b/app/api/cases/[caseId]/analysis/overview/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
-import { hasSupabaseServiceConfig } from '@/lib/environment';
+import { hasSupabaseServiceConfig, hasPartialSupabaseConfig } from '@/lib/environment';
 import { getCaseById, listCaseDocuments, listCaseAnalyses } from '@/lib/demo-data';
 
 const CORS_HEADERS: Record<string, string> = {
@@ -27,6 +27,17 @@ export async function GET(
   const params = await Promise.resolve(context.params);
   const { caseId } = params;
   const useSupabase = hasSupabaseServiceConfig();
+
+  if (hasPartialSupabaseConfig()) {
+    return withCors(
+      NextResponse.json(
+        {
+          error: 'Supabase service role key missing. Server-side analysis data cannot be fetched.',
+        },
+        { status: 500 }
+      )
+    );
+  }
 
   if (!useSupabase) {
     const caseRecord = getCaseById(caseId);

--- a/app/api/cases/[caseId]/analyze/route.ts
+++ b/app/api/cases/[caseId]/analyze/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
-import { hasSupabaseServiceConfig } from '@/lib/environment';
+import { hasSupabaseServiceConfig, hasPartialSupabaseConfig } from '@/lib/environment';
 import { processTimelineAnalysis } from '@/lib/workflows/timeline-analysis';
 import { runBackgroundTask } from '@/lib/background-tasks';
 import {
@@ -392,6 +392,19 @@ export async function POST(
   context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   const useSupabase = hasSupabaseServiceConfig();
+  const partialSupabaseConfig = hasPartialSupabaseConfig();
+
+  if (!useSupabase && partialSupabaseConfig) {
+    return withCors(
+      NextResponse.json(
+        {
+          error:
+            'Supabase service role key is missing. Add SUPABASE_SERVICE_ROLE_KEY to enable analysis workflows.',
+        },
+        { status: 500 }
+      )
+    );
+  }
   let resolvedCaseId = '';
   let createdJobId: string | null = null;
 

--- a/app/api/cases/[caseId]/processing-jobs/route.ts
+++ b/app/api/cases/[caseId]/processing-jobs/route.ts
@@ -15,6 +15,7 @@ import {
   getActiveJobs,
   getCaseDocumentStats,
 } from '@/lib/progress-tracker';
+import { hasPartialSupabaseConfig } from '@/lib/environment';
 
 export async function GET(
   request: NextRequest,
@@ -31,6 +32,16 @@ export async function GET(
       return NextResponse.json(
         { error: 'Case ID is required' },
         { status: 400 }
+      );
+    }
+
+    if (hasPartialSupabaseConfig()) {
+      return NextResponse.json(
+        {
+          error:
+            'Supabase service role key missing. Processing job data cannot be retrieved until SUPABASE_SERVICE_ROLE_KEY is set.',
+        },
+        { status: 500 }
       );
     }
 

--- a/app/api/cases/[caseId]/victim-timeline/route.ts
+++ b/app/api/cases/[caseId]/victim-timeline/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse, unstable_after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
-import { hasSupabaseServiceConfig } from '@/lib/environment';
+import { hasSupabaseServiceConfig, hasPartialSupabaseConfig } from '@/lib/environment';
 import { processVictimTimeline } from '@/lib/workflows/victim-timeline';
 import { listCaseDocuments, getStorageObject, addCaseAnalysis, getCaseById } from '@/lib/demo-data';
 import { buildVictimTimelineFallback } from '@/lib/victim-timeline-fallback';
@@ -44,6 +44,18 @@ export async function POST(
   let requestBody: any = null;
   try {
     const useSupabase = hasSupabaseServiceConfig();
+    const partialSupabaseConfig = hasPartialSupabaseConfig();
+    if (!useSupabase && partialSupabaseConfig) {
+      return withCors(
+        NextResponse.json(
+          {
+            error:
+              'Supabase service role key is missing. Victim timeline workflow cannot run without SUPABASE_SERVICE_ROLE_KEY.',
+          },
+          { status: 500 }
+        )
+      );
+    }
     const params = await Promise.resolve(context.params);
     const { caseId } = params;
     const body = await request.json();

--- a/app/api/cron/process-jobs/route.ts
+++ b/app/api/cron/process-jobs/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
-import { hasSupabaseServiceConfig } from '@/lib/environment';
+import { hasSupabaseServiceConfig, hasPartialSupabaseConfig } from '@/lib/environment';
 import { processTimelineAnalysis } from '@/lib/workflows/timeline-analysis';
 import { processDeepAnalysis } from '@/lib/workflows/deep-analysis';
 import { processVictimTimeline } from '@/lib/workflows/victim-timeline';
@@ -51,8 +51,11 @@ export async function GET(request: NextRequest) {
     }
 
     if (!hasSupabaseServiceConfig()) {
+      const errorMessage = hasPartialSupabaseConfig()
+        ? 'Supabase service role key missing - server jobs cannot run.'
+        : 'Supabase not configured';
       return NextResponse.json(
-        { error: 'Supabase not configured' },
+        { error: errorMessage },
         { status: 500 }
       );
     }

--- a/lib/environment.ts
+++ b/lib/environment.ts
@@ -5,8 +5,12 @@ export function hasSupabaseClientConfig(): boolean {
 export function hasSupabaseServiceConfig(): boolean {
   return Boolean(
     process.env.NEXT_PUBLIC_SUPABASE_URL &&
-      (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+      process.env.SUPABASE_SERVICE_ROLE_KEY
   );
+}
+
+export function hasPartialSupabaseConfig(): boolean {
+  return hasSupabaseClientConfig() && !hasSupabaseServiceConfig();
 }
 
 export function hasAnthropicConfig(): boolean {

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,14 +1,20 @@
 import { createClient } from '@supabase/supabase-js'
 import { Database } from '../app/types/database'
 import { createMockSupabaseClient } from './mock-supabase'
-import { hasSupabaseServiceConfig } from './environment'
+import { hasSupabaseServiceConfig, hasPartialSupabaseConfig } from './environment'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!hasSupabaseServiceConfig()) {
-  console.warn('[FreshEyes] Supabase environment variables missing. Falling back to local in-memory dataset.')
+  if (hasPartialSupabaseConfig()) {
+    console.error(
+      '[FreshEyes] Supabase client keys detected but SUPABASE_SERVICE_ROLE_KEY is missing. Server-side operations cannot run.'
+    )
+  } else {
+    console.warn('[FreshEyes] Supabase environment variables missing. Falling back to local in-memory dataset.')
+  }
 }
 
 export const supabaseServer = hasSupabaseServiceConfig() && supabaseUrl


### PR DESCRIPTION
## Summary
- require the Supabase service role key before treating the environment as fully configured
- add explicit API guards that surface helpful errors when only client keys are present
- log a clear server-side error so background analysis workflows no longer fail silently

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/v0-cracker/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691381ea174883258ad6b2dd2bcf3ac8)