### PR TITLE
Fix API call for analysis calling wrong function

### DIFF
--- a/VERCEL_DEPLOYMENT.md
+++ b/VERCEL_DEPLOYMENT.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-This application uses **Vercel Workflow DevKit** for durable background processing of AI analysis workflows. The workflows are designed to execute reliably with built-in retries and persistence.
+This application uses **Next.js `after` API** with **Fluid Compute** for durable background processing of AI analysis workflows. The workflows are designed to execute reliably after HTTP responses complete.
 
 ### Architecture
 
-**Primary Execution:** Workflows with `'use workflow'` and `'use step'` directives execute via Workflow DevKit with built-in durability and retries
+**Primary Execution:** Background workflows execute via Next.js `after()` API (requires Fluid Compute)
 **Fallback Analysis:** Heuristic-based analysis runs if Anthropic API is unavailable
 
 This dual-layer approach ensures workflows execute reliably even if one layer fails.
@@ -71,11 +71,12 @@ INNGEST_SIGNING_KEY=
 
 ### next.config.js
 
-The `experimental.after` flag is required for `unstable_after` to work:
+In Next.js 16, the `after` API is available by default (no experimental flag needed):
 
 ```javascript
 experimental: {
-  after: true,
+  // 'after' is now stable in Next.js 16+
+  after: true,  // Can be removed in future versions
 }
 ```
 
@@ -151,5 +152,5 @@ This provides:
 ## Further Reading
 
 - [Vercel Fluid Compute Documentation](https://vercel.com/docs/fluid-compute)
-- [Next.js unstable_after Documentation](https://nextjs.org/docs/app/api-reference/functions/unstable_after)
+- [Next.js after Documentation](https://nextjs.org/docs/app/api-reference/functions/after)
 - [Vercel Functions Timeouts](https://vercel.com/guides/what-can-i-do-about-vercel-serverless-functions-timing-out)

--- a/app/api/cases/[caseId]/analyze/route.ts
+++ b/app/api/cases/[caseId]/analyze/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { hasSupabaseServiceConfig } from '@/lib/environment';
 import { processTimelineAnalysis } from '@/lib/workflows/timeline-analysis';
@@ -503,7 +503,7 @@ export async function POST(
       },
       {
         label: 'Timeline Analysis API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Timeline Analysis API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/analyze/route.ts
+++ b/app/api/cases/[caseId]/analyze/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
-import { hasSupabaseServiceConfig } from '@/lib/environment';
+import { hasSupabaseServiceConfig, hasPartialSupabaseConfig } from '@/lib/environment';
 import { processTimelineAnalysis } from '@/lib/workflows/timeline-analysis';
 import { runBackgroundTask } from '@/lib/background-tasks';
 import {
@@ -392,6 +392,20 @@ export async function POST(
   context: { params: Promise<{ caseId: string }> | { caseId: string } }
 ) {
   const useSupabase = hasSupabaseServiceConfig();
+  const partialSupabaseConfig = hasPartialSupabaseConfig();
+
+  if (!useSupabase && partialSupabaseConfig) {
+    return withCors(
+      NextResponse.json(
+        {
+          error:
+            'Supabase service role key is missing. Add SUPABASE_SERVICE_ROLE_KEY to enable analysis workflows.',
+        },
+        { status: 500 }
+      )
+    );
+  }
+
   let resolvedCaseId = '';
   let createdJobId: string | null = null;
 

--- a/app/api/cases/[caseId]/behavioral-patterns/route.ts
+++ b/app/api/cases/[caseId]/behavioral-patterns/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processBehavioralPatterns } from '@/lib/workflows/behavioral-patterns';
 import { runBackgroundTask } from '@/lib/background-tasks';
@@ -99,7 +99,7 @@ export async function POST(
       },
       {
         label: 'Behavioral Patterns API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Behavioral Patterns API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/deep-analysis/route.ts
+++ b/app/api/cases/[caseId]/deep-analysis/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { hasSupabaseServiceConfig } from '@/lib/environment';
 import { processDeepAnalysis } from '@/lib/workflows/deep-analysis';
@@ -159,7 +159,7 @@ export async function POST(
       },
       {
         label: 'Deep Analysis API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Deep Analysis API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/evidence-gaps/route.ts
+++ b/app/api/cases/[caseId]/evidence-gaps/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processEvidenceGaps } from '@/lib/workflows/evidence-gaps';
 import { runBackgroundTask } from '@/lib/background-tasks';
@@ -99,7 +99,7 @@ export async function POST(
       },
       {
         label: 'Evidence Gaps API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Evidence Gaps API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/forensic-retesting/route.ts
+++ b/app/api/cases/[caseId]/forensic-retesting/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processForensicRetesting } from '@/lib/workflows/forensic-retesting';
 import { runBackgroundTask } from '@/lib/background-tasks';
@@ -99,7 +99,7 @@ export async function POST(
       },
       {
         label: 'Forensic Retesting API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Forensic Retesting API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/interrogation-questions/route.ts
+++ b/app/api/cases/[caseId]/interrogation-questions/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processInterrogationQuestions } from '@/lib/workflows/interrogation-questions';
 import { runBackgroundTask } from '@/lib/background-tasks';
@@ -99,7 +99,7 @@ export async function POST(
       },
       {
         label: 'Interrogation Questions API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Interrogation Questions API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/overlooked-details/route.ts
+++ b/app/api/cases/[caseId]/overlooked-details/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processOverlookedDetails } from '@/lib/workflows/overlooked-details';
 import { runBackgroundTask } from '@/lib/background-tasks';
@@ -99,7 +99,7 @@ export async function POST(
       },
       {
         label: 'Overlooked Details API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Overlooked Details API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/relationship-network/route.ts
+++ b/app/api/cases/[caseId]/relationship-network/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processRelationshipNetwork } from '@/lib/workflows/relationship-network';
 import { runBackgroundTask } from '@/lib/background-tasks';
@@ -99,7 +99,7 @@ export async function POST(
       },
       {
         label: 'Relationship Network API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Relationship Network API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/similar-cases/route.ts
+++ b/app/api/cases/[caseId]/similar-cases/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processSimilarCases } from '@/lib/workflows/similar-cases';
 import { runBackgroundTask } from '@/lib/background-tasks';
@@ -99,7 +99,7 @@ export async function POST(
       },
       {
         label: 'Similar Cases API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Similar Cases API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/api/cases/[caseId]/victim-timeline/route.ts
+++ b/app/api/cases/[caseId]/victim-timeline/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse, unstable_after } from 'next/server';
+import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { hasSupabaseServiceConfig } from '@/lib/environment';
 import { processVictimTimeline } from '@/lib/workflows/victim-timeline';
@@ -179,7 +179,7 @@ export async function POST(
       },
       {
         label: 'Victim Timeline API',
-        scheduler: unstable_after,
+        scheduler: after,
         onError: (error) => {
           console.error('[Victim Timeline API] Workflow failed:', error);
           // Workflow will update job status to 'failed' internally

--- a/app/cases/[caseId]/files/page.tsx
+++ b/app/cases/[caseId]/files/page.tsx
@@ -92,7 +92,13 @@ export default function CaseFilesPage() {
   };
 
   const runAnalysis = async (analysisType: 'timeline' | 'deep-analysis' | 'victim-timeline') => {
-    const endpoint = `/api/cases/${caseId}/${analysisType}`;
+    // Map button types to correct API endpoints
+    const endpointMap = {
+      'timeline': `/api/cases/${caseId}/analyze`,
+      'deep-analysis': `/api/cases/${caseId}/deep-analysis`,
+      'victim-timeline': `/api/cases/${caseId}/victim-timeline`,
+    };
+    const endpoint = endpointMap[analysisType];
 
     try {
       const body = analysisType === 'victim-timeline'

--- a/lib/background-tasks.ts
+++ b/lib/background-tasks.ts
@@ -42,7 +42,7 @@ export function runBackgroundTask(
         error
       );
     } else {
-      console.log(`[${label}] Using setTimeout scheduler (no unstable_after provided)`);
+      console.log(`[${label}] Using setTimeout scheduler (no after provided)`);
     }
     setTimeout(() => {
       void executeTask();
@@ -51,12 +51,12 @@ export function runBackgroundTask(
 
   if (scheduler) {
     try {
-      console.log(`[${label}] Scheduling with unstable_after...`);
+      console.log(`[${label}] Scheduling with after...`);
       scheduler(executeTask);
-      console.log(`[${label}] ✓ Successfully scheduled with unstable_after`);
+      console.log(`[${label}] ✓ Successfully scheduled with after`);
       return;
     } catch (error) {
-      console.error(`[${label}] ✗ unstable_after scheduler failed:`, error);
+      console.error(`[${label}] ✗ after scheduler failed:`, error);
       scheduleWithFallback('scheduler threw an error', error);
       return;
     }

--- a/lib/environment.ts
+++ b/lib/environment.ts
@@ -5,8 +5,12 @@ export function hasSupabaseClientConfig(): boolean {
 export function hasSupabaseServiceConfig(): boolean {
   return Boolean(
     process.env.NEXT_PUBLIC_SUPABASE_URL &&
-      (process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY)
+      process.env.SUPABASE_SERVICE_ROLE_KEY
   );
+}
+
+export function hasPartialSupabaseConfig(): boolean {
+  return hasSupabaseClientConfig() && !hasSupabaseServiceConfig();
 }
 
 export function hasAnthropicConfig(): boolean {

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,18 +1,24 @@
 import { createClient } from '@supabase/supabase-js'
 import { Database } from '../app/types/database'
 import { createMockSupabaseClient } from './mock-supabase'
-import { hasSupabaseServiceConfig } from './environment'
+import { hasSupabaseServiceConfig, hasPartialSupabaseConfig } from './environment'
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!hasSupabaseServiceConfig()) {
-  console.warn('[FreshEyes] Supabase environment variables missing. Falling back to local in-memory dataset.')
+  if (hasPartialSupabaseConfig()) {
+    console.error(
+      '[FreshEyes] Supabase client keys detected but SUPABASE_SERVICE_ROLE_KEY is missing. Server-side operations cannot run.'
+    )
+  } else {
+    console.warn('[FreshEyes] Supabase environment variables missing. Falling back to local in-memory dataset.')
+  }
 }
 
-export const supabaseServer = hasSupabaseServiceConfig() && supabaseUrl
-  ? createClient<Database>(supabaseUrl, supabaseServiceKey || supabaseAnonKey || '', {
+export const supabaseServer = hasSupabaseServiceConfig() && supabaseUrl && supabaseServiceKey
+  ? createClient<Database>(supabaseUrl, supabaseServiceKey, {
       auth: {
         autoRefreshToken: false,
         persistSession: false,

--- a/lib/workflows/deep-analysis.ts
+++ b/lib/workflows/deep-analysis.ts
@@ -2,7 +2,7 @@
  * Workflow: Deep/Comprehensive Cold Case Analysis
  *
  * Performs comprehensive 8-dimension cold case analysis asynchronously.
- * This workflow runs in the background using Next.js unstable_after.
+ * This workflow runs in the background using Next.js after.
  *
  * Requires Fluid Compute enabled in Vercel for reliable execution.
  */

--- a/lib/workflows/timeline-analysis.ts
+++ b/lib/workflows/timeline-analysis.ts
@@ -2,7 +2,7 @@
  * Workflow: Timeline Analysis
  *
  * Performs asynchronous timeline extraction and conflict detection.
- * This workflow runs in the background using Next.js unstable_after.
+ * This workflow runs in the background using Next.js after.
  *
  * Requires Fluid Compute enabled in Vercel for reliable execution.
  */

--- a/lib/workflows/victim-timeline.ts
+++ b/lib/workflows/victim-timeline.ts
@@ -2,7 +2,7 @@
  * Workflow: Victim Timeline Reconstruction
  *
  * Generates comprehensive victim movement timeline with gap analysis.
- * This workflow runs in the background using Next.js unstable_after.
+ * This workflow runs in the background using Next.js after.
  *
  * Requires Fluid Compute enabled in Vercel for reliable execution.
  */

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,8 @@ const nextConfig = {
   },
   // Enable experimental features for Next.js 15/16
   experimental: {
-    // Enable unstable_after API for background task execution
+    // Enable 'after' API for background task execution
+    // In Next.js 16+, this is stable and the flag can be removed
     // With Fluid Compute enabled in Vercel, this allows workflows to run
     // in the background after HTTP responses complete
     after: true,


### PR DESCRIPTION
✅ All Fixes Applied:
Root Cause Fixed (commit 30a966a): Timeline Analysis button was calling wrong endpoint
Next.js 16 API Updated (commit f40b8b9): Changed unstable_after → after
Better Config Errors (commit cab82af): Clear messages when SUPABASE_SERVICE_ROLE_KEY is missing
📋 Summary of Changes:
Timeline Analysis now calls /api/cases/{caseId}/analyze (not /timeline)
Using after() API instead of non-existent unstable_after
Detects partial Supabase config and shows helpful error messages
Better logging distinguishes "no Supabase" vs "misconfigured Supabase"