### PR TITLE
Enforce cron secret validation for cron job endpoint

### DIFF
--- a/app/api/cron/process-jobs/route.ts
+++ b/app/api/cron/process-jobs/route.ts
@@ -24,9 +24,13 @@ function isValidCronRequest(request: NextRequest): boolean {
     return true;
   }
 
-  // In production, verify the cron secret
-  if (cronSecret && authHeader === `Bearer ${cronSecret}`) {
-    return true;
+  // In production, verify the cron secret when configured
+  if (cronSecret) {
+    if (authHeader === `Bearer ${cronSecret}`) {
+      return true;
+    }
+
+    return false;
   }
 
   // Vercel automatically adds this header for cron jobs


### PR DESCRIPTION
## Summary
- require CRON_SECRET authentication before allowing the Vercel cron user-agent fallback
- keep development mode permissive for local testing

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138663821c8325b9029dac628949a0)