### PR TITLE
Add Brain icon import for Anti-Portfolio navigation

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,0 +1,66 @@
+import type { LucideIcon } from "lucide-react"
+import {
+  BarChart2,
+  BookOpen,
+  Brain,
+  CandlestickChart,
+  CircleDollarSign,
+  ClipboardList,
+  LayoutDashboard,
+  LineChart,
+  TrendingUp,
+} from "lucide-react"
+
+export type NavigationItem = {
+  title: string
+  href: string
+  icon: LucideIcon
+}
+
+export const navigationItems: NavigationItem[] = [
+  {
+    title: "Dashboard",
+    href: "/",
+    icon: LayoutDashboard,
+  },
+  {
+    title: "Trading Journal",
+    href: "/journal",
+    icon: BookOpen,
+  },
+  {
+    title: "Strategies",
+    href: "/strategies",
+    icon: ClipboardList,
+  },
+  {
+    title: "Performance",
+    href: "/performance",
+    icon: BarChart2,
+  },
+  {
+    title: "Risk Analyzer",
+    href: "/risk",
+    icon: LineChart,
+  },
+  {
+    title: "Options Flow",
+    href: "/flow",
+    icon: CandlestickChart,
+  },
+  {
+    title: "Anti-Portfolio",
+    href: "/anti-portfolio",
+    icon: Brain,
+  },
+  {
+    title: "Watchlists",
+    href: "/watchlists",
+    icon: TrendingUp,
+  },
+  {
+    title: "Capital Allocation",
+    href: "/capital",
+    icon: CircleDollarSign,
+  },
+]


### PR DESCRIPTION
## Summary
- add a navigation definition for dashboard links including the Anti-Portfolio entry
- ensure the new Anti-Portfolio link references the Brain icon from lucide-react

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913870d512883259c1cd6f32996039b)