### PR TITLE
Fix deep analysis fallbacks for PDF parsing and question generation

### DIFF
--- a/lib/cold-case-analyzer.ts
+++ b/lib/cold-case-analyzer.ts
@@ -1084,8 +1084,21 @@ function fallbackGenerateInterrogationQuestions(
     ? suspect.inconsistencies
     : ['Timeline gaps between museum departure and overlook arrival'];
 
+  const normalizedInconsistencies = focusInconsistencies.map(item => {
+    if (typeof item === 'string') return item;
+    if (item === null || item === undefined) return '';
+    try {
+      return String(item);
+    } catch {
+      return '';
+    }
+  }).map(item => item.trim()).filter(item => item.length > 0);
+
   const weakPoints = [...new Set([
-    ...focusInconsistencies.map(item => item.split(':')[0] || item),
+    ...normalizedInconsistencies.map(item => {
+      const safeItem = item || '';
+      return safeItem.includes(':') ? safeItem.split(':')[0] || safeItem : safeItem;
+    }),
     ...suspect.relationships.slice(0, 2),
   ])].filter(Boolean);
 
@@ -1106,7 +1119,7 @@ function fallbackGenerateInterrogationQuestions(
     };
   };
 
-  const questions = focusInconsistencies.slice(0, 4).map((topic, index) => buildQuestion(topic, index));
+  const questions = normalizedInconsistencies.slice(0, 4).map((topic, index) => buildQuestion(topic, index));
 
   questions.push({
     question: 'Why did multiple witnesses describe your mood differently than you reported? What changed after leaving the museum?',
@@ -1120,12 +1133,12 @@ function fallbackGenerateInterrogationQuestions(
     psychologicalTechnique: 'Good Cop / Bad Cop setup',
   });
 
-  const knownLies = focusInconsistencies.filter(item => /lie|false|contradiction/i.test(item));
+  const knownLies = normalizedInconsistencies.filter(item => /lie|false|contradiction/i.test(item));
 
   return {
     suspectName: suspect.name,
     knownLies,
-    inconsistencies: focusInconsistencies,
+    inconsistencies: normalizedInconsistencies,
     weakPoints,
     questions,
     overallStrategy:

--- a/lib/document-parser.ts
+++ b/lib/document-parser.ts
@@ -11,6 +11,7 @@
 import { supabaseServer } from './supabase-server';
 import Tesseract from 'tesseract.js';
 import OpenAI from 'openai';
+import pdfParse from 'pdf-parse';
 
 type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
 
@@ -190,13 +191,8 @@ async function extractFromPDF(buffer: Buffer): Promise<ExtractionResult> {
   const pdfjs = await loadPdfJsModule();
 
   if (!pdfjs) {
-    return {
-      text: '[Unable to load PDF parser module]',
-      method: 'pdfjs-dist',
-      confidence: 0,
-      error: 'pdfjs module failed to load',
-      needsReview: true,
-    };
+    console.warn('[Document Parser] pdfjs module unavailable, falling back to pdf-parse.');
+    return extractWithPdfParse(buffer);
   }
 
   const loadingTask = pdfjs.getDocument({ data: new Uint8Array(buffer) });
@@ -250,14 +246,8 @@ async function extractFromPDF(buffer: Buffer): Promise<ExtractionResult> {
       uncertainSegments: hasMeaningfulText ? [] : undefined,
     };
   } catch (error: any) {
-    console.error('[Document Parser] PDF extraction failed:', error);
-    return {
-      text: '',
-      method: 'pdfjs-dist',
-      confidence: 0,
-      error: `PDF extraction failed: ${error.message}`,
-      needsReview: true,
-    };
+    console.error('[Document Parser] PDF extraction failed, attempting pdf-parse fallback:', error);
+    return extractWithPdfParse(buffer);
   } finally {
     try {
       if (typeof loadingTask.destroy === 'function') {
@@ -266,6 +256,36 @@ async function extractFromPDF(buffer: Buffer): Promise<ExtractionResult> {
     } catch (destroyError) {
       console.warn('[Document Parser] Failed to destroy PDF loading task', destroyError);
     }
+  }
+}
+
+async function extractWithPdfParse(buffer: Buffer): Promise<ExtractionResult> {
+  try {
+    const result = await pdfParse(buffer);
+    const text = result.text?.trim() || '';
+    const hasMeaningfulText = text.length > 0;
+    const pageCount = result.numpages || result.numrender || undefined;
+
+    return {
+      text: hasMeaningfulText ? text : '[No extractable text found in this PDF]',
+      pageCount,
+      method: 'pdf-parse',
+      confidence: hasMeaningfulText ? 0.75 : 0.1,
+      metadata: {
+        pageCount,
+        info: result.info,
+      },
+      needsReview: !hasMeaningfulText,
+    };
+  } catch (error: any) {
+    console.error('[Document Parser] pdf-parse fallback failed:', error);
+    return {
+      text: '',
+      method: 'pdf-parse',
+      confidence: 0,
+      error: `PDF extraction failed: ${error.message}`,
+      needsReview: true,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add a pdf-parse fallback when pdfjs fails to load so PDF extraction still succeeds during deep analysis
- normalize interrogation inconsistencies before deriving weak points to prevent non-string values from causing runtime errors

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/v0-cracker/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913c13518888325af694a4bc921f2fb)