### PR TITLE
Wrap Supabase auth UI in session provider

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { Auth } from '@supabase/auth-ui-react';
 import { ThemeSupa } from '@supabase/auth-ui-shared';
+import { SessionContextProvider } from '@supabase/auth-helpers-react';
 import { supabase } from '@/lib/supabase-client';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -61,28 +62,30 @@ export default function LoginPage() {
   }
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-4">
-      <h1 className="text-2xl font-bold mb-4">Sign in to ColdCaseAI</h1>
-      <div className="w-full max-w-md">
-        <Auth
-          supabaseClient={supabase}
-          appearance={{ theme: ThemeSupa }}
-          theme="light"
-          providers={[]}
-          redirectTo={`${typeof window !== 'undefined' ? window.location.origin : ''}/`}
-        />
-      </div>
+    <SessionContextProvider supabaseClient={supabase}>
+      <main className="flex flex-col items-center justify-center min-h-screen p-4">
+        <h1 className="text-2xl font-bold mb-4">Sign in to ColdCaseAI</h1>
+        <div className="w-full max-w-md">
+          <Auth
+            supabaseClient={supabase}
+            appearance={{ theme: ThemeSupa }}
+            theme="light"
+            providers={[]}
+            redirectTo={`${typeof window !== 'undefined' ? window.location.origin : ''}/`}
+          />
+        </div>
 
-      {/* Magic Link Login */}
-      <MagicLinkForm />
+        {/* Magic Link Login */}
+        <MagicLinkForm />
 
-      {/* Debug info */}
-      <div className="mt-8 p-4 bg-gray-100 rounded text-sm">
-        <p><strong>Debug Info:</strong></p>
-        <p>Supabase URL: {process.env.NEXT_PUBLIC_SUPABASE_URL ? '✅ Set' : '❌ Missing'}</p>
-        <p>Supabase Key: {process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? '✅ Set' : '❌ Missing'}</p>
-      </div>
-    </main>
+        {/* Debug info */}
+        <div className="mt-8 p-4 bg-gray-100 rounded text-sm">
+          <p><strong>Debug Info:</strong></p>
+          <p>Supabase URL: {process.env.NEXT_PUBLIC_SUPABASE_URL ? '✅ Set' : '❌ Missing'}</p>
+          <p>Supabase Key: {process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? '✅ Set' : '❌ Missing'}</p>
+        </div>
+      </main>
+    </SessionContextProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- wrap the login page auth UI with Supabase's SessionContextProvider so the Auth component can access a session context
- import the provider from `@supabase/auth-helpers-react`

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/v0-cracker/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913fc5c03a883259e722538d69937e4)