### PR TITLE
Improve PDF ingestion resilience

### DIFF
--- a/lib/extraction-outcome.ts
+++ b/lib/extraction-outcome.ts
@@ -1,0 +1,104 @@
+import type { ExtractionResult } from './document-parser';
+import type { DocumentChunkRow } from './document-chunker';
+
+export interface ExtractionErrorLog {
+  code: string;
+  message: string;
+  method: ExtractionResult['method'];
+  detail?: string;
+  timestamp: string;
+}
+
+export interface ChunkPersistencePlan {
+  status: 'completed' | 'failed';
+  updates: {
+    content?: string | null;
+    extraction_confidence?: number | null;
+    extraction_method?: ExtractionResult['method'] | null;
+    error_log?: string | null;
+    processed_at?: string | null;
+    metadata?: any;
+  };
+  contentForEmbedding: string | null;
+  error: ExtractionErrorLog | null;
+}
+
+const NO_TEXT_PLACEHOLDER = '[No extractable text';
+
+function deriveErrorCode(method: ExtractionResult['method']): string {
+  if (method === 'pdfjs-dist' || method === 'pdf-parse') {
+    return 'PDF_EXTRACTION_FAILED';
+  }
+  if (method && method.startsWith('ocr-')) {
+    return 'OCR_EXTRACTION_FAILED';
+  }
+  if (method === 'whisper-transcription') {
+    return 'AUDIO_TRANSCRIPTION_FAILED';
+  }
+  return 'DOCUMENT_EXTRACTION_FAILED';
+}
+
+function cloneMetadata(metadata: DocumentChunkRow['metadata']): Record<string, any> {
+  if (metadata && typeof metadata === 'object') {
+    return JSON.parse(JSON.stringify(metadata));
+  }
+  return {};
+}
+
+export function deriveChunkPersistencePlan(
+  chunk: Pick<DocumentChunkRow, 'metadata'>,
+  result: ExtractionResult
+): ChunkPersistencePlan {
+  const now = new Date().toISOString();
+  const rawText = (result.text || '').trim();
+  const isPlaceholderText = rawText.length === 0 || rawText.startsWith(NO_TEXT_PLACEHOLDER);
+  const baseMetadata = cloneMetadata(chunk.metadata);
+
+  const sharedMetadata = {
+    ...baseMetadata,
+    extractionMethod: result.method,
+    pageCount: result.pageCount,
+    processingTimestamp: now,
+  };
+
+  if (result.error || isPlaceholderText) {
+    const error: ExtractionErrorLog = {
+      code: deriveErrorCode(result.method),
+      message: result.error || 'Document parser did not return extractable text.',
+      method: result.method,
+      detail: !result.error && isPlaceholderText ? 'Parser returned placeholder text.' : undefined,
+      timestamp: now,
+    };
+
+    return {
+      status: 'failed',
+      updates: {
+        content: null,
+        extraction_confidence: result.confidence ?? 0,
+        extraction_method: result.method,
+        error_log: JSON.stringify(error),
+        processed_at: now,
+        metadata: {
+          ...sharedMetadata,
+          extractionError: error,
+        },
+      },
+      contentForEmbedding: null,
+      error,
+    };
+  }
+
+  return {
+    status: 'completed',
+    updates: {
+      content: rawText,
+      extraction_confidence: result.confidence ?? null,
+      extraction_method: result.method,
+      error_log: null,
+      processed_at: now,
+      metadata: sharedMetadata,
+    },
+    contentForEmbedding: rawText,
+    error: null,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "cleanup:stuck-jobs": "npx tsx lib/cleanup-stuck-jobs.ts",
     "cleanup:stuck-jobs:delete": "npx tsx lib/cleanup-stuck-jobs.ts --delete",
-    "cleanup:stuck-jobs:dry-run": "npx tsx lib/cleanup-stuck-jobs.ts --dry-run"
+    "cleanup:stuck-jobs:dry-run": "npx tsx lib/cleanup-stuck-jobs.ts --dry-run",
+    "test": "node tests/run-tests.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",

--- a/tests/document-ingestion.integration.test.ts
+++ b/tests/document-ingestion.integration.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+
+import { deriveChunkPersistencePlan } from '../lib/extraction-outcome';
+import { extractDocumentContentFromBuffer } from '../lib/document-parser';
+
+async function run() {
+  const malformedPdf = Buffer.from('This is not a valid PDF document');
+
+  const extraction = await extractDocumentContentFromBuffer('malformed.pdf', malformedPdf);
+
+  assert.ok(extraction.error, 'extraction should surface an error message');
+  assert.equal(extraction.text.trim().length, 0, 'no text should be returned for malformed input');
+
+  const plan = deriveChunkPersistencePlan({ metadata: { pageNumber: 1 } } as any, extraction);
+
+  assert.equal(plan.status, 'failed');
+  assert.equal(plan.contentForEmbedding, null);
+  assert.ok(plan.error, 'plan should include structured error payload');
+  assert.equal(plan.error?.code, 'PDF_EXTRACTION_FAILED');
+  assert.ok(plan.updates.error_log, 'error log should be persisted');
+
+  const parsedLog = JSON.parse(plan.updates.error_log!);
+  assert.equal(parsedLog.code, plan.error?.code);
+  assert.equal(parsedLog.message, plan.error?.message);
+}
+
+run().then(() => {
+  if (process.env.DEBUG_TESTS) {
+    console.log('malformed PDF triggers structured ingestion failure ✅');
+  }
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/document-ingestion.integration.test.ts
+++ b/tests/document-ingestion.integration.test.ts
@@ -10,6 +10,8 @@ async function run() {
 
   assert.ok(extraction.error, 'extraction should surface an error message');
   assert.equal(extraction.text.trim().length, 0, 'no text should be returned for malformed input');
+  assert.equal(extraction.method, 'pdfjs-dist', 'malformed PDFs should fail without pdf-parse fallback');
+  assert.equal(extraction.needsReview, true, 'malformed PDFs should be flagged for review');
 
   const plan = deriveChunkPersistencePlan({ metadata: { pageNumber: 1 } } as any, extraction);
 

--- a/tests/register-ts.js
+++ b/tests/register-ts.js
@@ -1,0 +1,21 @@
+const fs = require('node:fs');
+const ts = require('typescript');
+
+const compilerOptions = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+  resolveJsonModule: true,
+  jsx: ts.JsxEmit.ReactJSX,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+};
+
+require.extensions['.ts'] = function registerTsExtension(module, filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const transformed = ts.transpileModule(source, {
+    compilerOptions,
+    fileName: filename,
+    reportDiagnostics: false,
+  });
+  return module._compile(transformed.outputText, filename);
+};

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,2 @@
+require('./register-ts');
+require('./document-ingestion.integration.test.ts');


### PR DESCRIPTION
## Summary
- ensure pdfjs-dist is loaded server-side with graceful fallbacks and expose a buffer-based helper for tests
- guard the pdf-parse compatibility shim for server runtimes and persist structured extraction failures when chunking
- add a runtime TypeScript loader and integration test to verify malformed PDFs record ingestion failures

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913fccb02888325a340ee47d29ed352)