### PR TITLE
Fix server PDF parsing DOMMatrix reference error

### DIFF
--- a/lib/document-parser.ts
+++ b/lib/document-parser.ts
@@ -17,16 +17,6 @@ type PdfjsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs');
 
 let pdfjsModulePromise: Promise<PdfjsModule | null> | null = null;
 
-// Polyfill DOMMatrix for Node.js environment
-if (typeof globalThis.DOMMatrix === 'undefined') {
-  // @ts-ignore - Polyfill for Node.js
-  globalThis.DOMMatrix = class DOMMatrix {
-    constructor() {
-      // Minimal DOMMatrix implementation for pdfjs-dist compatibility
-    }
-  };
-}
-
 async function loadPdfJsModule(): Promise<PdfjsModule | null> {
   // DISABLED: pdfjs-dist requires full DOMMatrix implementation which is not available in Node.js
   // The DOMMatrix polyfill is insufficient for pdfjs-dist's canvas operations

--- a/lib/pdf-parse-compat.ts
+++ b/lib/pdf-parse-compat.ts
@@ -1,3 +1,4 @@
+import '../polyfills/dom-matrix';
 import { PDFParse } from 'pdf-parse';
 
 interface LegacyPdfParseResult {

--- a/lib/polyfills/dom-matrix.ts
+++ b/lib/polyfills/dom-matrix.ts
@@ -1,0 +1,28 @@
+/**
+ * Minimal DOMMatrix polyfill for Node.js environments.
+ *
+ * Some pdf.js based libraries expect `globalThis.DOMMatrix` to exist. When the
+ * API routes run on the server this class is missing which causes a
+ * `ReferenceError` during module evaluation and prevents the handlers from
+ * loading. We only need a minimal stub so the constructors resolve without
+ * throwing. Any functionality that depends on the full DOMMatrix math API is
+ * unused in our document parsing pipeline because we rely on `pdf-parse`, which
+ * only checks for the presence of the constructor.
+ */
+
+if (typeof globalThis.DOMMatrix === 'undefined') {
+  class DOMMatrixPolyfill {
+    constructor(init?: DOMMatrixInit | string) {
+      // Store the input so debugging is easier if a library unexpectedly uses it
+      // in the future. The values are otherwise unused by our server runtime.
+      if (init) {
+        (this as any)._init = init;
+      }
+    }
+  }
+
+  // @ts-ignore - Node's global scope does not declare DOMMatrix.
+  globalThis.DOMMatrix = DOMMatrixPolyfill;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a dedicated DOMMatrix polyfill module so server handlers can safely import pdf parsing libraries
- ensure the pdf-parse compatibility layer loads the polyfill and rely on it instead of duplicating the stub in the document parser

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/v0-cracker/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913fd0dc0108325b9d1670fef27af96)