### PR TITLE
Improve investigation board auto population

### DIFF
--- a/app/api/cases/[caseId]/board/route.ts
+++ b/app/api/cases/[caseId]/board/route.ts
@@ -6,6 +6,85 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
+import { populateInvestigationBoardFromDocuments } from '@/lib/jobs/populate-investigation-board';
+import { Database } from '@/app/types/database';
+
+interface BoardResponseData {
+  entities: Database['public']['Tables']['case_entities']['Row'][];
+  connections: Database['public']['Tables']['case_connections']['Row'][];
+  timeline_events: Database['public']['Tables']['timeline_events']['Row'][];
+  alibis: Database['public']['Tables']['alibi_entries']['Row'][];
+  summary: any;
+}
+
+async function fetchBoardRecords(caseId: string): Promise<BoardResponseData> {
+  const [entitiesResult, connectionsResult, timelineResult, alibisResult, summaryResult] = await Promise.all([
+    supabaseServer.from('case_entities').select('*').eq('case_id', caseId).order('created_at', { ascending: false }),
+    supabaseServer.from('case_connections').select('*').eq('case_id', caseId).order('created_at', { ascending: false }),
+    supabaseServer.from('timeline_events').select('*').eq('case_id', caseId).order('event_time', { ascending: true }),
+    supabaseServer.from('alibi_entries').select('*').eq('case_id', caseId).order('statement_date', { ascending: false }),
+    supabaseServer.rpc('get_case_board_summary', { p_case_id: caseId }),
+  ]);
+
+  if (entitiesResult.error) {
+    throw new Error(`Failed to fetch entities: ${entitiesResult.error.message}`);
+  }
+
+  if (connectionsResult.error) {
+    throw new Error(`Failed to fetch connections: ${connectionsResult.error.message}`);
+  }
+
+  if (timelineResult.error) {
+    throw new Error(`Failed to fetch timeline: ${timelineResult.error.message}`);
+  }
+
+  if (alibisResult.error) {
+    throw new Error(`Failed to fetch alibis: ${alibisResult.error.message}`);
+  }
+
+  const summaryData = summaryResult.error ? {} : summaryResult.data || {};
+
+  return {
+    entities: entitiesResult.data || [],
+    connections: connectionsResult.data || [],
+    timeline_events: timelineResult.data || [],
+    alibis: alibisResult.data || [],
+    summary: summaryData,
+  };
+}
+
+function isBoardDataEmpty(data: BoardResponseData) {
+  return (
+    data.entities.length === 0 &&
+    data.connections.length === 0 &&
+    data.timeline_events.length === 0 &&
+    data.alibis.length === 0
+  );
+}
+
+async function hasCaseContent(caseId: string) {
+  const [{ data: caseFiles, error: caseFileError }, { data: caseDocuments, error: caseDocumentError }] = await Promise.all([
+    supabaseServer
+      .from('case_files')
+      .select('id')
+      .eq('case_id', caseId)
+      .limit(1),
+    supabaseServer
+      .from('case_documents')
+      .select('id')
+      .eq('case_id', caseId)
+      .limit(1),
+  ]);
+
+  if (caseFileError) {
+    console.warn('[Board API] Unable to verify case files presence:', caseFileError);
+  }
+  if (caseDocumentError) {
+    console.warn('[Board API] Unable to verify case documents presence:', caseDocumentError);
+  }
+
+  return Boolean((caseFiles && caseFiles.length > 0) || (caseDocuments && caseDocuments.length > 0));
+}
 
 export async function GET(
   request: NextRequest,
@@ -15,40 +94,36 @@ export async function GET(
     const params = await Promise.resolve(context.params);
     const { caseId } = params;
 
-    // Fetch all board data in parallel
-    const [entitiesResult, connectionsResult, timelineResult, alibisResult, summaryResult] = await Promise.all([
-      supabaseServer.from('case_entities').select('*').eq('case_id', caseId).order('created_at', { ascending: false }),
-      supabaseServer.from('case_connections').select('*').eq('case_id', caseId).order('created_at', { ascending: false }),
-      supabaseServer.from('timeline_events').select('*').eq('case_id', caseId).order('event_time', { ascending: true }),
-      supabaseServer.from('alibi_entries').select('*').eq('case_id', caseId).order('statement_date', { ascending: false }),
-      supabaseServer.rpc('get_case_board_summary', { p_case_id: caseId })
-    ]);
+    const initialData = await fetchBoardRecords(caseId);
 
-    if (entitiesResult.error) {
-      throw new Error(`Failed to fetch entities: ${entitiesResult.error.message}`);
-    }
+    if (isBoardDataEmpty(initialData) && (await hasCaseContent(caseId))) {
+      console.log(`[Board API] No existing board data found for case ${caseId}. Attempting auto population.`);
 
-    if (connectionsResult.error) {
-      throw new Error(`Failed to fetch connections: ${connectionsResult.error.message}`);
-    }
+      try {
+        const populateResult = await populateInvestigationBoardFromDocuments({ caseId });
+        const totalInserted =
+          (populateResult?.entities || 0) +
+          (populateResult?.events || 0) +
+          (populateResult?.connections || 0) +
+          (populateResult?.alibis || 0);
 
-    if (timelineResult.error) {
-      throw new Error(`Failed to fetch timeline: ${timelineResult.error.message}`);
-    }
-
-    if (alibisResult.error) {
-      throw new Error(`Failed to fetch alibis: ${alibisResult.error.message}`);
+        if (totalInserted > 0) {
+          const refreshedData = await fetchBoardRecords(caseId);
+          return NextResponse.json({
+            success: true,
+            data: refreshedData,
+            autoPopulated: true,
+          });
+        }
+      } catch (populationError) {
+        console.error('[Board API] Auto population failed:', populationError);
+      }
     }
 
     return NextResponse.json({
       success: true,
-      data: {
-        entities: entitiesResult.data || [],
-        connections: connectionsResult.data || [],
-        timeline_events: timelineResult.data || [],
-        alibis: alibisResult.data || [],
-        summary: summaryResult.data || {},
-      },
+      data: initialData,
+      autoPopulated: false,
     });
   } catch (error: any) {
     console.error('[Board API] Error:', error);

--- a/app/cases/[caseId]/board/page.tsx
+++ b/app/cases/[caseId]/board/page.tsx
@@ -23,6 +23,13 @@ interface BoardData {
   summary: any;
 }
 
+interface BoardApiResponse {
+  success: boolean;
+  data: BoardData;
+  autoPopulated?: boolean;
+  error?: string;
+}
+
 export default function InvestigationBoardPage() {
   const params = useParams();
   const router = useRouter();
@@ -39,7 +46,7 @@ export default function InvestigationBoardPage() {
       if (showToast) setIsRefreshing(true);
 
       const response = await fetch(`/api/cases/${caseId}/board`);
-      const result = await response.json();
+      const result: BoardApiResponse = await response.json();
 
       if (!response.ok) {
         throw new Error(result.error || 'Failed to fetch board data');
@@ -47,7 +54,9 @@ export default function InvestigationBoardPage() {
 
       setBoardData(result.data);
 
-      if (showToast) {
+      if (result.autoPopulated) {
+        toast.success('Investigation board auto-populated from case documents');
+      } else if (showToast) {
         toast.success('Board data refreshed');
       }
 


### PR DESCRIPTION
## Summary
- automatically populate investigation board data when tables are empty by reusing the document parsing pipeline
- expose auto-population feedback in the investigation board UI so investigators know when records are generated
- broaden fallback document collection to leverage aggregated text and avoid duplicate processing when parsing case files

## Testing
- npm run lint *(fails: Next.js CLI reports "Invalid project directory provided" when running in this environment)*
- npm test *(fails: integration harness depends on pdfjs-dist and a valid PDF payload in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914118438948325b2275b9a2c29a323)