### PR TITLE
Improve Supabase document text resolution for case analysis

### DIFF
--- a/tests/analyze-route.integration.test.ts
+++ b/tests/analyze-route.integration.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+
+import { gatherDocumentsForAnalysis } from '../app/api/cases/[caseId]/analyze/route';
+import { supabaseServer } from '../lib/supabase-server';
+
+async function run() {
+  const originalFrom = (supabaseServer as any).from;
+  const originalStorage = (supabaseServer as any).storage;
+
+  const fakeDocuments = [
+    {
+      file_name: 'Investigation Summary.pdf',
+      document_type: 'report',
+      storage_path: null,
+      metadata: {
+        extracted_text: '[No extracted text available for Investigation Summary.pdf]',
+        processed_text: 'Case summary generated from processing pipeline.',
+        pages: [
+          { text: 'Page 1 fragment' },
+          { text: 'Page 2 fragment' },
+        ],
+      },
+    },
+    {
+      file_name: 'Audio Interview.mp3',
+      document_type: 'audio_transcript',
+      storage_path: 'case-123/audio-interview.txt',
+      metadata: {
+        extracted_text: '[No extracted text available for Audio Interview.mp3]',
+      },
+    },
+    {
+      file_name: 'Placeholder Note.txt',
+      document_type: 'note',
+      storage_path: null,
+      metadata: {
+        extracted_text: '[No extracted text available for Placeholder Note.txt]',
+      },
+    },
+  ];
+
+  const storageText = 'Transcribed conversation from Supabase storage.';
+
+  try {
+    (supabaseServer as any).from = (table: string) => {
+      if (table !== 'case_documents') {
+        return originalFrom.call(supabaseServer, table);
+      }
+
+      return {
+        select() {
+          return {
+            eq() {
+              return Promise.resolve({ data: fakeDocuments, error: null });
+            },
+          };
+        },
+      };
+    };
+
+    (supabaseServer as any).storage = {
+      from(bucket: string) {
+        if (bucket !== 'case-files') {
+          return originalStorage.from(bucket);
+        }
+
+        return {
+          async download(path: string) {
+            if (path === 'case-123/audio-interview.txt') {
+              const buffer = Buffer.from(storageText, 'utf-8');
+              return {
+                data: {
+                  async arrayBuffer() {
+                    return buffer;
+                  },
+                },
+                error: null,
+              };
+            }
+
+            return {
+              data: null,
+              error: { message: 'not found' },
+            };
+          },
+        };
+      },
+    };
+
+    const documents = await gatherDocumentsForAnalysis('case-123', true);
+
+    assert.equal(documents.length, 2, 'documents with real content should be retained');
+
+    const summaryDoc = documents.find((doc) => doc.filename === 'Investigation Summary.pdf');
+    assert.ok(summaryDoc, 'summary document should be present');
+    assert.equal(
+      summaryDoc?.content,
+      'Case summary generated from processing pipeline.',
+      'metadata processed_text should be preferred over placeholder'
+    );
+    assert.ok(!/No extracted text/i.test(summaryDoc!.content));
+
+    const audioDoc = documents.find((doc) => doc.filename === 'Audio Interview.mp3');
+    assert.ok(audioDoc, 'audio document should be present');
+    assert.equal(
+      audioDoc?.content,
+      storageText,
+      'storage blob should be decoded into UTF-8 text when metadata is empty'
+    );
+
+    assert.ok(!documents.some((doc) => doc.filename === 'Placeholder Note.txt'));
+  } finally {
+    (supabaseServer as any).from = originalFrom;
+    (supabaseServer as any).storage = originalStorage;
+  }
+}
+
+run()
+  .then(() => {
+    if (process.env.DEBUG_TESTS) {
+      console.log('analyze route gathers document content ✅');
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/register-ts.js
+++ b/tests/register-ts.js
@@ -1,5 +1,36 @@
 const fs = require('node:fs');
+const path = require('node:path');
+const Module = require('module');
 const ts = require('typescript');
+
+const baseUrl = path.resolve(__dirname, '..');
+
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function patchedResolve(request, parent, isMain, options) {
+  if (typeof request === 'string') {
+    if (request.startsWith('@/')) {
+      const resolved = path.join(baseUrl, request.slice(2));
+      return originalResolveFilename.call(this, resolved, parent, isMain, options);
+    }
+
+    if (request.startsWith('pdfjs-dist/')) {
+      try {
+        return originalResolveFilename.call(this, request, parent, isMain, options);
+      } catch (error) {
+        const nestedRequest = path.join(
+          baseUrl,
+          'node_modules',
+          'pdf-parse',
+          'node_modules',
+          request
+        );
+        return originalResolveFilename.call(this, nestedRequest, parent, isMain, options);
+      }
+    }
+  }
+
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
 
 const compilerOptions = {
   module: ts.ModuleKind.CommonJS,

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,2 +1,3 @@
 require('./register-ts');
 require('./document-ingestion.integration.test.ts');
+require('./analyze-route.integration.test.ts');


### PR DESCRIPTION
## Summary
- expand the analysis route to harvest text from nested metadata, decode Supabase storage blobs, and ignore placeholder content before invoking the AI analysis
- add an integration harness that stubs Supabase to verify gatherDocumentsForAnalysis only forwards real document text
- update the TypeScript test loader to resolve project aliases and the nested pdfjs-dist dependency used by existing ingestion tests

## Testing
- npm test --silent

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69142110c9d88325aef917d4b3d2f8ba)