### PR TITLE
Fix relationship network mapping and comprehensive analysis display

### DIFF
--- a/app/cases/[caseId]/analysis/page.tsx
+++ b/app/cases/[caseId]/analysis/page.tsx
@@ -56,8 +56,14 @@ export default function AnalysisPage() {
     return analysisData;
   };
 
-  const normalizeAnalysisType = (analysisType: string) =>
-    analysisType === 'victim_timeline' ? 'victim-timeline' : analysisType;
+  const normalizeAnalysisType = (analysisType: string) => {
+    if (!analysisType) return analysisType;
+    if (analysisType === 'victim_timeline') return 'victim-timeline';
+    if (analysisType === 'comprehensive_cold_case' || analysisType === 'comprehensive-cold-case') {
+      return 'deep-analysis';
+    }
+    return analysisType;
+  };
 
   const isTimelineAnalysisType = (analysisType: string) => {
     const normalizedType = normalizeAnalysisType(analysisType);


### PR DESCRIPTION
## Summary
- ensure comprehensive cold case analysis results render with the rich UI instead of falling back to raw JSON by normalizing the stored analysis type
- normalize relationship network inputs so suspects, witnesses, and extracted document content are provided to the analyzer and fallback heuristics
- update background workflows and jobs to pass structured documents, compute connection counts, and persist richer metadata

## Testing
- npm run lint *(fails: Invalid project directory provided, no such directory: /workspace/v0-cracker/lint)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691431c5b27c83259d55feb180b38134)