### PR TITLE
Improve forensic retesting workflow data hygiene

### DIFF
--- a/lib/cold-case-analyzer.ts
+++ b/lib/cold-case-analyzer.ts
@@ -1557,9 +1557,9 @@ const FORENSIC_TECH_SUGGESTIONS: Array<{
 function fallbackRecommendForensicRetesting(
   evidenceInventory: {
     item: string;
-    dateCollected: string;
-    testingPerformed: string;
-    results: string;
+    dateCollected?: string;
+    testingPerformed?: string;
+    results?: string;
   }[],
 ): ForensicReExamination[] {
   return evidenceInventory.map((evidence, index) => {
@@ -1588,10 +1588,10 @@ function fallbackRecommendForensicRetesting(
 export async function recommendForensicRetesting(
   evidenceInventory: {
     item: string;
-    dateCollected: string;
-    testingPerformed: string;
-    results: string;
-  }[]
+    dateCollected?: string;
+    testingPerformed?: string;
+    results?: string;
+  }[],
 ): Promise<ForensicReExamination[]> {
 
   if (!evidenceInventory.length) {

--- a/lib/forensic-retesting-utils.ts
+++ b/lib/forensic-retesting-utils.ts
@@ -1,0 +1,131 @@
+import type { ForensicReExamination } from './cold-case-analyzer';
+
+export interface AnalyzerEvidenceInput {
+  item: string;
+  dateCollected?: string;
+  testingPerformed?: string;
+  results?: string;
+}
+
+const PLACEHOLDER_VALUES = new Set([
+  'unknown',
+  'not documented',
+  'n/a',
+  'na',
+  'none',
+]);
+
+function coerceString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  const normalized = trimmed.toLowerCase();
+  if (PLACEHOLDER_VALUES.has(normalized)) return undefined;
+
+  return trimmed;
+}
+
+function coerceDate(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return undefined;
+}
+
+export function mapEvidenceRowsToAnalyzerInput(
+  rows: Array<Record<string, any>>,
+): AnalyzerEvidenceInput[] {
+  return rows.map((row, index) => {
+    const item =
+      coerceString(row.file_name) ||
+      coerceString(row.evidence_label) ||
+      coerceString(row.evidence_type) ||
+      coerceString(row.description) ||
+      `Evidence #${index + 1}`;
+
+    const dateCollected =
+      coerceDate(row.date_collected) ||
+      coerceDate(row.collected_at) ||
+      coerceDate(row.created_at);
+
+    const testingPerformed =
+      coerceString(row.testing_performed) ||
+      coerceString(row.lab_notes) ||
+      coerceString(row.notes);
+
+    const results =
+      coerceString(row.testing_results) ||
+      coerceString(row.results) ||
+      coerceString(row.analysis_summary);
+
+    return {
+      item,
+      dateCollected,
+      testingPerformed: testingPerformed || undefined,
+      results: results || undefined,
+    };
+  });
+}
+
+export function sanitizeForensicRecommendations(
+  recommendations: ForensicReExamination[],
+): ForensicReExamination[] {
+  return recommendations.map(rec => {
+    const cleanString = (value: string | undefined): string =>
+      coerceString(value) || '';
+
+    const cleanArray = (values: string[] | undefined): string[] =>
+      (values || [])
+        .map(coerceString)
+        .filter((value): value is string => Boolean(value));
+
+    return {
+      ...rec,
+      originalTesting: cleanString(rec.originalTesting),
+      newTechnologiesAvailable: cleanArray(rec.newTechnologiesAvailable),
+      whyRetest: cleanString(rec.whyRetest),
+      potentialFindings: cleanArray(rec.potentialFindings),
+      costEstimate: cleanString(rec.costEstimate),
+      exampleSuccessStories: cleanString(rec.exampleSuccessStories),
+    };
+  });
+}
+
+export interface ForensicRecommendationSummary {
+  totalRecommendations: number;
+  highPriority: number;
+  uniqueNewTechnologies: number;
+  whyRetestHighlights: string[];
+}
+
+export function summarizeForensicRecommendations(
+  recommendations: ForensicReExamination[],
+): ForensicRecommendationSummary {
+  const uniqueTech = new Set<string>();
+  const rationaleHighlights: string[] = [];
+
+  recommendations.forEach(rec => {
+    (rec.newTechnologiesAvailable || []).forEach(tech => {
+      const cleaned = coerceString(tech);
+      if (cleaned) uniqueTech.add(cleaned);
+    });
+
+    const rationale = coerceString(rec.whyRetest);
+    if (rationale && rationaleHighlights.length < 3) {
+      rationaleHighlights.push(rationale);
+    }
+  });
+
+  return {
+    totalRecommendations: recommendations.length,
+    highPriority: recommendations.filter(rec => rec.priority === 'high' || rec.priority === 'critical').length,
+    uniqueNewTechnologies: uniqueTech.size,
+    whyRetestHighlights: rationaleHighlights,
+  };
+}

--- a/tests/forensic-retesting-utils.test.ts
+++ b/tests/forensic-retesting-utils.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+
+import type { ForensicReExamination } from '../lib/cold-case-analyzer';
+import {
+  mapEvidenceRowsToAnalyzerInput,
+  sanitizeForensicRecommendations,
+  summarizeForensicRecommendations,
+} from '../lib/forensic-retesting-utils';
+
+function testEvidenceMappingMatchesAnalyzerShape() {
+  const rows = [
+    {
+      file_name: 'Bloody swab from hallway banister',
+      created_at: '2020-02-12T10:20:30.000Z',
+      notes: 'Initial DNA extraction yielded partial profile',
+      testing_results: 'Partial STR profile',
+    },
+    {
+      evidence_type: 'Fiber sample',
+      date_collected: '2018-09-01',
+      notes: 'Unknown',
+      analysis_summary: 'Trace blue fiber consistent with denim',
+    },
+  ];
+
+  const mapped = mapEvidenceRowsToAnalyzerInput(rows);
+
+  assert.equal(mapped.length, 2);
+  assert.deepEqual(Object.keys(mapped[0]), ['item', 'dateCollected', 'testingPerformed', 'results']);
+  assert.equal(mapped[0].item, 'Bloody swab from hallway banister');
+  assert.equal(mapped[0].testingPerformed, 'Initial DNA extraction yielded partial profile');
+  assert.equal(mapped[0].results, 'Partial STR profile');
+  assert.equal(mapped[1].item, 'Fiber sample');
+  assert.equal(mapped[1].testingPerformed, undefined);
+  assert.equal(mapped[1].results, 'Trace blue fiber consistent with denim');
+}
+
+function testSanitizeRemovesPlaceholderValues() {
+  const recommendations: ForensicReExamination[] = [
+    {
+      evidenceItem: 'Fiber sample',
+      originalTesting: 'Unknown',
+      newTechnologiesAvailable: ['Touch DNA recovery', 'Unknown'],
+      whyRetest: 'Unknown',
+      potentialFindings: ['Identify new contributors', 'Unknown'],
+      costEstimate: 'Unknown',
+      priority: 'high',
+      exampleSuccessStories: 'Unknown',
+    },
+  ];
+
+  const sanitized = sanitizeForensicRecommendations(recommendations);
+
+  assert.equal(sanitized[0].originalTesting, '');
+  assert.deepEqual(sanitized[0].newTechnologiesAvailable, ['Touch DNA recovery']);
+  assert.equal(sanitized[0].whyRetest, '');
+  assert.deepEqual(sanitized[0].potentialFindings, ['Identify new contributors']);
+  assert.equal(sanitized[0].costEstimate, '');
+  assert.equal(sanitized[0].exampleSuccessStories, '');
+}
+
+function testSummaryReflectsAnalyzerFields() {
+  const recommendations: ForensicReExamination[] = [
+    {
+      evidenceItem: 'Bloody swab from hallway banister',
+      originalTesting: 'Initial STR run in 2010',
+      newTechnologiesAvailable: ['Touch DNA recovery', 'Next-generation sequencing'],
+      whyRetest: 'Apply higher-sensitivity DNA sequencing to low-yield sample.',
+      potentialFindings: ['Full STR profile'],
+      costEstimate: '$1,200',
+      priority: 'critical',
+      exampleSuccessStories: 'Golden State Killer genealogy breakthrough',
+    },
+    {
+      evidenceItem: 'Fiber sample',
+      originalTesting: '',
+      newTechnologiesAvailable: ['Micro trace analysis'],
+      whyRetest: 'Corroborate suspect presence through trace transfer patterns.',
+      potentialFindings: ['Link fibers to suspect vehicle'],
+      costEstimate: '$800',
+      priority: 'high',
+      exampleSuccessStories: '',
+    },
+  ];
+
+  const summary = summarizeForensicRecommendations(recommendations);
+
+  assert.equal(summary.totalRecommendations, 2);
+  assert.equal(summary.highPriority, 2);
+  assert.equal(summary.uniqueNewTechnologies, 3);
+  assert.deepEqual(summary.whyRetestHighlights, [
+    'Apply higher-sensitivity DNA sequencing to low-yield sample.',
+    'Corroborate suspect presence through trace transfer patterns.',
+  ]);
+}
+
+function run() {
+  testEvidenceMappingMatchesAnalyzerShape();
+  testSanitizeRemovesPlaceholderValues();
+  testSummaryReflectsAnalyzerFields();
+}
+
+run();


### PR DESCRIPTION
## Summary
- map case evidence rows into the analyzer's expected structure while removing placeholder values
- sanitize and summarize forensic retesting recommendations before saving workflow/job results
- add unit tests that exercise the mapping, sanitization, and summary helpers for forensic retesting data

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69150adc15148325ad3e16a8f38382ce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced forensic evidence data handling supporting optional metadata fields
  * Added comprehensive forensic recommendation summaries with priority classification and technology insights

* **Refactor**
  * Improved evidence processing pipeline with new data normalization utilities
  * Updated recommendation generation workflow for better data consistency

* **Tests**
  * Added test coverage for evidence mapping and recommendation sanitization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->