### PR TITLE
Add structured analysis views for analyzer outputs

### DIFF
--- a/components/analysis/BehavioralPatternsView.tsx
+++ b/components/analysis/BehavioralPatternsView.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AlertTriangle, Brain, Filter, MessageSquare, Target, Users } from 'lucide-react';
+import type { BehaviorPattern } from '@/lib/cold-case-analyzer';
+import { cleanText, displayText, formatPercent, clamp01 } from '@/lib/display-utils';
+
+interface BehavioralPatternsViewProps {
+  patterns: BehaviorPattern[];
+}
+
+interface SanitizedPattern extends BehaviorPattern {
+  personName: string;
+  patterns: BehaviorPattern['patterns'];
+  recommendedFollowUp: string[];
+}
+
+export default function BehavioralPatternsView({ patterns }: BehavioralPatternsViewProps) {
+  const [minSuspicion, setMinSuspicion] = useState(0.4);
+  const [search, setSearch] = useState('');
+
+  const sanitized = useMemo(() => {
+    return patterns
+      .map<SanitizedPattern>(pattern => ({
+        ...pattern,
+        personName: displayText(pattern.personName, 'Unnamed interviewee'),
+        patterns: (pattern.patterns || []).filter(entry => Boolean(cleanText(entry.description))),
+        recommendedFollowUp: (pattern.recommendedFollowUp || [])
+          .map(entry => cleanText(entry))
+          .filter((entry): entry is string => Boolean(entry)),
+        overallAssessment: displayText(pattern.overallAssessment, 'Assessment not provided'),
+      }))
+      .filter(entry => entry.patterns.length > 0);
+  }, [patterns]);
+
+  const filtered = useMemo(() => {
+    return sanitized.filter(entry => {
+      const matchesThreshold = entry.patterns.some(item => item.suspicionLevel >= minSuspicion);
+      const matchesSearch = !search
+        ? true
+        : entry.personName.toLowerCase().includes(search.toLowerCase());
+      return matchesThreshold && matchesSearch;
+    });
+  }, [sanitized, minSuspicion, search]);
+
+  const avgSuspicion = useMemo(() => {
+    const scores = sanitized.flatMap(entry => entry.patterns.map(pattern => pattern.suspicionLevel));
+    if (!scores.length) return 0;
+    return scores.reduce((acc, score) => acc + score, 0) / scores.length;
+  }, [sanitized]);
+
+  const highRiskCount = useMemo(
+    () => sanitized.filter(entry => entry.patterns.some(pattern => pattern.suspicionLevel >= 0.7)).length,
+    [sanitized],
+  );
+
+  const totalFlags = sanitized.reduce((acc, entry) => acc + entry.patterns.length, 0);
+
+  const suspicionPercent = formatPercent(clamp01(avgSuspicion));
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+          <div className="flex items-center gap-2 text-amber-800 text-sm font-semibold">
+            <AlertTriangle className="h-4 w-4" />
+            High-Risk Subjects
+          </div>
+          <p className="mt-2 text-2xl font-bold text-amber-900">{highRiskCount}</p>
+          <p className="text-xs text-amber-700">Showing people with patterns ≥ 70% suspicion</p>
+        </div>
+        <div className="rounded-xl border border-blue-200 bg-blue-50 p-4">
+          <div className="flex items-center gap-2 text-blue-800 text-sm font-semibold">
+            <Brain className="h-4 w-4" />
+            Average Suspicion
+          </div>
+          <p className="mt-2 text-2xl font-bold text-blue-900">{suspicionPercent}</p>
+          <div className="mt-2 h-2 w-full rounded-full bg-blue-100">
+            <div
+              className="h-full rounded-full bg-blue-500"
+              style={{ width: `${clamp01(avgSuspicion) * 100}%` }}
+            />
+          </div>
+        </div>
+        <div className="rounded-xl border border-purple-200 bg-purple-50 p-4">
+          <div className="flex items-center gap-2 text-purple-800 text-sm font-semibold">
+            <MessageSquare className="h-4 w-4" />
+            Pattern Flags
+          </div>
+          <p className="mt-2 text-2xl font-bold text-purple-900">{totalFlags}</p>
+          <p className="text-xs text-purple-700">Behavioral clues captured across interviews</p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-white p-4">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <Filter className="h-4 w-4" />
+            Suspicion threshold
+            <span className="font-semibold text-gray-900">{Math.round(minSuspicion * 100)}%</span>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={Math.round(minSuspicion * 100)}
+            onChange={event => setMinSuspicion(Number(event.target.value) / 100)}
+            className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-gray-200"
+          />
+          <input
+            type="search"
+            placeholder="Search interviewees"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            className="flex-1 rounded-lg border px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {filtered.map(entry => (
+          <div key={entry.personName} className="rounded-xl border bg-white p-4 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-3">
+              <div>
+                <p className="text-sm uppercase tracking-wide text-gray-500">Interviewee</p>
+                <p className="text-xl font-semibold text-gray-900">{entry.personName}</p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3 text-sm">
+                <span className="rounded-full bg-gray-100 px-3 py-1 text-gray-700">
+                  {entry.patterns.length} pattern{entry.patterns.length === 1 ? '' : 's'} detected
+                </span>
+                <span className="rounded-full bg-blue-50 px-3 py-1 text-blue-700">
+                  Top concern{' '}
+                  {entry.patterns[0]?.type.replace(/_/g, ' ') ?? 'not specified'}
+                </span>
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              {entry.patterns.map(pattern => (
+                <div key={`${entry.personName}-${pattern.type}`} className="rounded-lg border p-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+                      <Users className="h-4 w-4 text-gray-500" />
+                      {pattern.type.replace(/_/g, ' ')}
+                    </div>
+                    <span className="rounded-full border border-gray-200 px-2 py-0.5 text-xs font-medium">
+                      {formatPercent(pattern.suspicionLevel)}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm text-gray-600">{pattern.description}</p>
+                  <div className="mt-3 space-y-1 text-xs text-gray-500">
+                    {pattern.examples.slice(0, 2).map((example, index) => (
+                      <p key={index} className="rounded bg-gray-50 p-2">“{example}”</p>
+                    ))}
+                  </div>
+                  <p className="mt-3 text-xs text-gray-500">
+                    Psychological note: {pattern.psychologicalNote}
+                  </p>
+                  <div className="mt-3 h-2 rounded-full bg-gray-100">
+                    <div
+                      className="h-2 rounded-full bg-gradient-to-r from-amber-400 to-red-500"
+                      style={{ width: `${clamp01(pattern.suspicionLevel) * 100}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {entry.recommendedFollowUp.length > 0 && (
+              <div className="mt-4 rounded-lg bg-slate-50 p-3 text-sm text-slate-800">
+                <div className="flex items-center gap-2 font-semibold">
+                  <Target className="h-4 w-4" />
+                  Follow-up actions
+                </div>
+                <ul className="mt-2 list-disc space-y-1 pl-5">
+                  {entry.recommendedFollowUp.map(action => (
+                    <li key={action}>{action}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="rounded-lg border border-dashed bg-white p-6 text-center text-sm text-gray-600">
+            No interviews meet the current filters. Try lowering the suspicion slider or clearing the search.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/analysis/EvidenceGapsView.tsx
+++ b/components/analysis/EvidenceGapsView.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AlertTriangle, CheckCircle, Filter, Layers, Target } from 'lucide-react';
+import type { EvidenceGap } from '@/lib/cold-case-analyzer';
+import { displayText, formatPercent, clamp01 } from '@/lib/display-utils';
+
+interface EvidenceGapsViewProps {
+  gaps: EvidenceGap[];
+}
+
+const priorityOrder: EvidenceGap['priority'][] = ['critical', 'high', 'medium', 'low'];
+
+const priorityStyles: Record<EvidenceGap['priority'], string> = {
+  critical: 'bg-red-100 text-red-800 border-red-200',
+  high: 'bg-orange-100 text-orange-800 border-orange-200',
+  medium: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+  low: 'bg-blue-100 text-blue-800 border-blue-200',
+};
+
+export default function EvidenceGapsView({ gaps }: EvidenceGapsViewProps) {
+  const [priorityFilter, setPriorityFilter] = useState<'all' | EvidenceGap['priority']>('all');
+  const [search, setSearch] = useState('');
+
+  const sanitized = useMemo(() => {
+    return gaps
+      .map(gap => ({
+        ...gap,
+        category: gap.category,
+        gapDescription: displayText(gap.gapDescription, 'Gap description not provided'),
+        whyItMatters: displayText(gap.whyItMatters, 'Significance not provided'),
+        howToFill: displayText(gap.howToFill, 'Action not available'),
+        estimatedEffort: displayText(gap.estimatedEffort, 'Effort not documented'),
+      }))
+      .sort((a, b) => priorityOrder.indexOf(a.priority) - priorityOrder.indexOf(b.priority));
+  }, [gaps]);
+
+  const filtered = useMemo(() => {
+    return sanitized.filter(gap => {
+      if (priorityFilter !== 'all' && gap.priority !== priorityFilter) {
+        return false;
+      }
+      if (search) {
+        const normalized = search.toLowerCase();
+        return (
+          gap.category.toLowerCase().includes(normalized) ||
+          gap.gapDescription.toLowerCase().includes(normalized) ||
+          gap.whyItMatters.toLowerCase().includes(normalized)
+        );
+      }
+      return true;
+    });
+  }, [sanitized, priorityFilter, search]);
+
+  const counts = useMemo(() => {
+    return sanitized.reduce(
+      (acc, gap) => {
+        acc[gap.priority] += 1;
+        return acc;
+      },
+      { critical: 0, high: 0, medium: 0, low: 0 },
+    );
+  }, [sanitized]);
+
+  const breakthroughAverage = useMemo(() => {
+    if (!sanitized.length) return 0;
+    return sanitized.reduce((acc, gap) => acc + clamp01(gap.potentialBreakthroughValue), 0) / sanitized.length;
+  }, [sanitized]);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        {priorityOrder.map(priority => (
+          <div key={priority} className="rounded-lg border bg-white p-4">
+            <div className="text-xs uppercase tracking-wide text-gray-500">{priority} priority</div>
+            <p className="mt-2 text-2xl font-semibold text-gray-900">{counts[priority]}</p>
+            <p className="text-xs text-gray-500">gaps to close</p>
+          </div>
+        ))}
+        <div className="rounded-lg border bg-gradient-to-r from-blue-600 to-indigo-600 p-4 text-white">
+          <p className="text-xs uppercase tracking-wide text-white/80">Avg. breakthrough potential</p>
+          <p className="mt-2 text-3xl font-semibold">{formatPercent(breakthroughAverage)}</p>
+          <p className="text-xs text-white/80">Re-run high-value gaps quarterly</p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-white p-4">
+        <div className="flex flex-wrap gap-4">
+          <label className="flex items-center gap-2 text-sm text-gray-600">
+            <Filter className="h-4 w-4" />
+            Priority
+            <select
+              value={priorityFilter}
+              onChange={event => setPriorityFilter(event.target.value as typeof priorityFilter)}
+              className="rounded-lg border px-2 py-1 text-sm"
+            >
+              <option value="all">All</option>
+              {priorityOrder.map(priority => (
+                <option key={priority} value={priority}>
+                  {priority}
+                </option>
+              ))}
+            </select>
+          </label>
+          <input
+            type="search"
+            placeholder="Search categories or notes"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            className="flex-1 rounded-lg border px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {filtered.map(gap => (
+          <div key={`${gap.category}-${gap.gapDescription}`} className="rounded-xl border bg-white p-4 shadow-sm">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-500">Category</p>
+                <p className="text-lg font-semibold text-gray-900">{gap.category}</p>
+              </div>
+              <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${priorityStyles[gap.priority]}`}>
+                {gap.priority}
+              </span>
+            </div>
+            <p className="mt-3 text-sm text-gray-800">{gap.gapDescription}</p>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-3">
+              <div className="rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
+                <div className="flex items-center gap-2 font-semibold">
+                  <AlertTriangle className="h-4 w-4" />
+                  Why it matters
+                </div>
+                <p className="mt-2 text-xs text-slate-600">{gap.whyItMatters}</p>
+              </div>
+              <div className="rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
+                <div className="flex items-center gap-2 font-semibold">
+                  <Target className="h-4 w-4" />
+                  How to fill
+                </div>
+                <p className="mt-2 text-xs text-slate-600">{gap.howToFill}</p>
+              </div>
+              <div className="rounded-lg bg-slate-50 p-3 text-sm text-slate-700">
+                <div className="flex items-center gap-2 font-semibold">
+                  <Layers className="h-4 w-4" />
+                  Effort & value
+                </div>
+                <p className="mt-1 text-xs text-slate-600">
+                  Effort: <span className="font-semibold text-slate-900">{gap.estimatedEffort}</span>
+                </p>
+                <p className="text-xs text-slate-600">Breakthrough: {formatPercent(gap.potentialBreakthroughValue)}</p>
+                <div className="mt-2 h-2 rounded-full bg-white">
+                  <div
+                    className="h-2 rounded-full bg-gradient-to-r from-green-400 to-emerald-600"
+                    style={{ width: `${clamp01(gap.potentialBreakthroughValue) * 100}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+
+        {filtered.length === 0 && (
+          <div className="rounded-lg border border-dashed bg-white p-6 text-center text-sm text-gray-600">
+            No gaps match these filters yet. Try selecting another priority level.
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-slate-900 p-4 text-white">
+        <div className="flex items-start gap-3">
+          <CheckCircle className="h-5 w-5 text-emerald-300" />
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-white/80">Next best moves</p>
+            <p className="mt-1 text-sm text-white/80">
+              Re-run collection plans for the top two critical gaps and sync results with the forensic task force dashboard.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/analysis/RelationshipNetworkView.tsx
+++ b/components/analysis/RelationshipNetworkView.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AlertTriangle, Filter, Link2, Radar, Users } from 'lucide-react';
+import type { RelationshipNetworkAnalysis, RelationshipNode } from '@/lib/cold-case-analyzer';
+import { cleanText, displayText } from '@/lib/display-utils';
+
+interface RelationshipNetworkViewProps {
+  analysis: RelationshipNetworkAnalysis;
+}
+
+const roleLabels: Record<RelationshipNode['role'], string> = {
+  victim: 'Victim',
+  suspect: 'Suspect',
+  witness: 'Witness',
+  family: 'Family',
+  associate: 'Associate',
+  unknown: 'Unspecified',
+};
+
+export default function RelationshipNetworkView({ analysis }: RelationshipNetworkViewProps) {
+  const [roleFilter, setRoleFilter] = useState<'all' | RelationshipNode['role']>('all');
+  const [showSuspiciousOnly, setShowSuspiciousOnly] = useState(false);
+
+  const sanitizedNodes = useMemo(() => {
+    return (analysis.nodes || []).map(node => ({
+      ...node,
+      name: displayText(node.name, 'Unnamed person'),
+      alibi: displayText(node.alibi, 'Not documented'),
+      motive: displayText(node.motive, 'Not documented'),
+      opportunity: displayText(node.opportunity, 'Not documented'),
+    }));
+  }, [analysis.nodes]);
+
+  const filteredNodes = useMemo(() => {
+    return sanitizedNodes.filter(node => {
+      if (roleFilter !== 'all' && node.role !== roleFilter) {
+        return false;
+      }
+      if (showSuspiciousOnly) {
+        return node.connections?.some(connection => connection.suspicious);
+      }
+      return true;
+    });
+  }, [sanitizedNodes, roleFilter, showSuspiciousOnly]);
+
+  const suspiciousEdges = useMemo(
+    () => (analysis.relationships || []).filter(edge => edge.suspicious),
+    [analysis.relationships],
+  );
+
+  const hiddenConnections = analysis.hiddenConnections || [];
+
+  const clusterCount = analysis.clusters?.length ?? 0;
+
+  const highlightedConnectors = useMemo(() => {
+    const connectors = analysis.insights?.primaryConnectors || [];
+    const cleaned = connectors
+      .map(name => cleanText(name))
+      .filter((name): name is string => Boolean(name));
+    return cleaned.slice(0, 3).join(', ') || 'Not identified';
+  }, [analysis.insights?.primaryConnectors]);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-4">
+        <div className="rounded-xl border bg-white p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-500">People tracked</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{sanitizedNodes.length}</p>
+          <p className="text-xs text-gray-500">{clusterCount} network cluster{clusterCount === 1 ? '' : 's'}</p>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-500">Suspicious links</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{suspiciousEdges.length}</p>
+          <p className="text-xs text-gray-500">flagged for re-interview</p>
+        </div>
+        <div className="rounded-xl border bg-white p-4">
+          <p className="text-xs uppercase tracking-wide text-gray-500">Hidden connections</p>
+          <p className="mt-2 text-2xl font-semibold text-gray-900">{hiddenConnections.length}</p>
+          <p className="text-xs text-gray-500">surfaced via documents</p>
+        </div>
+        <div className="rounded-xl border bg-slate-900 p-4 text-white">
+          <p className="text-xs uppercase tracking-wide text-white/80">Primary connectors</p>
+          <p className="mt-2 text-sm font-semibold">{highlightedConnectors}</p>
+          <p className="text-xs text-white/70">Monitor their communications this week</p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border bg-white p-4">
+        <div className="flex flex-wrap gap-4">
+          <label className="flex items-center gap-2 text-sm text-gray-600">
+            <Filter className="h-4 w-4" />
+            Role
+            <select
+              value={roleFilter}
+              onChange={event => setRoleFilter(event.target.value as typeof roleFilter)}
+              className="rounded-lg border px-2 py-1 text-sm"
+            >
+              <option value="all">All roles</option>
+              {Object.keys(roleLabels).map(role => (
+                <option key={role} value={role}>
+                  {roleLabels[role as RelationshipNode['role']]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex items-center gap-2 text-sm text-gray-600">
+            <input
+              type="checkbox"
+              checked={showSuspiciousOnly}
+              onChange={event => setShowSuspiciousOnly(event.target.checked)}
+              className="h-4 w-4 rounded border-gray-300"
+            />
+            Only show suspicious links
+          </label>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {filteredNodes.map(node => (
+          <div key={node.name} className="rounded-xl border bg-white p-4 shadow-sm">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-500">{roleLabels[node.role]}</p>
+                <p className="text-lg font-semibold text-gray-900">{node.name}</p>
+              </div>
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-700">
+                {node.connections?.length ?? 0} connections
+              </span>
+            </div>
+            <div className="mt-3 space-y-1 text-xs text-gray-600">
+              <p>Alibi: {node.alibi}</p>
+              <p>Motive: {node.motive}</p>
+              <p>Opportunity: {node.opportunity}</p>
+            </div>
+            {node.connections?.length ? (
+              <div className="mt-4 space-y-2">
+                {node.connections.slice(0, 3).map(connection => (
+                  <div key={`${node.name}-${connection.to}-${connection.type}`} className="rounded-lg border p-3 text-sm">
+                    <div className="flex items-center justify-between text-gray-900">
+                      <span>{connection.to}</span>
+                      {connection.suspicious && (
+                        <span className="flex items-center gap-1 text-xs text-red-600">
+                          <AlertTriangle className="h-3 w-3" />
+                          Suspicious
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-gray-500">{connection.type} link · Strength {(connection.strength * 100).toFixed(0)}%</p>
+                    <p className="mt-1 text-xs text-gray-600">{displayText(connection.notes, 'No notes recorded')}</p>
+                  </div>
+                ))}
+                {node.connections.length > 3 && (
+                  <p className="text-xs text-gray-500">+{node.connections.length - 3} more connections logged</p>
+                )}
+              </div>
+            ) : (
+              <p className="mt-3 text-xs text-gray-500">No active links recorded yet.</p>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {hiddenConnections.length > 0 && (
+        <div className="rounded-xl border bg-white p-4 shadow-sm">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+            <Link2 className="h-4 w-4 text-gray-500" />
+            Hidden connections to review
+          </div>
+          <div className="mt-4 space-y-3">
+            {hiddenConnections.map(connection => {
+              const personOne = displayText(connection.person1, 'Not specified');
+              const personTwo = displayText(connection.person2, 'Not specified');
+              return (
+                <div key={`${connection.person1}-${connection.person2}`} className="rounded-lg border p-3 text-sm">
+                  <div className="flex items-center justify-between text-gray-900">
+                    <span>
+                      {personOne} ⇄ {personTwo}
+                    </span>
+                    <span className="text-xs uppercase text-gray-500">{displayText(connection.connectionType, 'link')}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-600">{displayText(connection.whyItMatters, 'Significance not provided')}</p>
+                  {connection.discoveredFrom?.length > 0 && (
+                    <p className="mt-1 text-xs text-gray-500">
+                      Found in: {connection.discoveredFrom.join(', ')}
+                    </p>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {analysis.clusters && analysis.clusters.length > 0 && (
+        <div className="rounded-xl border bg-white p-4 shadow-sm">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+            <Radar className="h-4 w-4 text-gray-500" />
+            Cluster insights
+          </div>
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            {analysis.clusters.map(cluster => (
+              <div key={cluster.label} className="rounded-lg border p-3 text-sm">
+                <p className="text-xs uppercase tracking-wide text-gray-500">{cluster.label}</p>
+                <p className="text-lg font-semibold text-gray-900">{cluster.members.length} members</p>
+                <p className="text-xs text-gray-600">Dominant role: {roleLabels[cluster.dominantRole]}</p>
+                <p className="mt-2 text-xs text-gray-600">Risk: {cluster.riskLevel}</p>
+                <p className="mt-2 text-xs text-gray-500">{cluster.summary}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {analysis.insights && (
+        <div className="rounded-xl border bg-white p-4 shadow-sm">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+            <Users className="h-4 w-4 text-gray-500" />
+            Follow-up recommendations
+          </div>
+          <div className="mt-4 grid gap-4 md:grid-cols-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Primary connectors</p>
+              <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                {(analysis.insights.primaryConnectors || ['Not identified']).map(connector => (
+                  <li key={connector}>{displayText(connector, 'Not identified')}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Potential conflicts</p>
+              <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                {(analysis.insights.potentialConflicts || ['None flagged']).map(conflict => (
+                  <li key={conflict}>{displayText(conflict, 'None flagged')}</li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-gray-500">Recommended follow-up</p>
+              <ul className="mt-2 space-y-1 text-sm text-gray-700">
+                {(analysis.insights.recommendedFollowUp || ['No actions recorded']).map(action => (
+                  <li key={action}>{displayText(action, 'No actions recorded')}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/display-utils.ts
+++ b/lib/display-utils.ts
@@ -1,0 +1,23 @@
+export function cleanText(value?: string | null): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.toLowerCase();
+  if (normalized === 'unknown') return null;
+  if (normalized.startsWith('placeholder:')) return null;
+  return trimmed;
+}
+
+export function displayText(value?: string | null, fallback = 'Not specified'): string {
+  return cleanText(value) ?? fallback;
+}
+
+export function formatPercent(value?: number | null, fallback = '—'): string {
+  if (typeof value !== 'number' || Number.isNaN(value)) return fallback;
+  return `${Math.round(value * 100)}%`;
+}
+
+export function clamp01(value: number): number {
+  if (Number.isNaN(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}

--- a/tests/analysis-components.test.tsx
+++ b/tests/analysis-components.test.tsx
@@ -1,0 +1,115 @@
+import assert from 'node:assert';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import BehavioralPatternsView from '@/components/analysis/BehavioralPatternsView';
+import EvidenceGapsView from '@/components/analysis/EvidenceGapsView';
+import RelationshipNetworkView from '@/components/analysis/RelationshipNetworkView';
+import type {
+  BehaviorPattern,
+  EvidenceGap,
+  RelationshipNetworkAnalysis,
+} from '@/lib/cold-case-analyzer';
+
+function assertIncludes(haystack: string, needle: string, message: string) {
+  assert.ok(haystack.includes(needle), message);
+}
+
+function assertNotIncludes(haystack: string, needle: string, message: string) {
+  assert.ok(!haystack.includes(needle), message);
+}
+
+(() => {
+  const data: BehaviorPattern[] = [
+    {
+      personName: 'placeholder:Witness Alpha',
+      patterns: [
+        {
+          type: 'evasion',
+          description: 'Avoided sharing specifics about the drive home.',
+          examples: ['I just kind of went straight home, I guess.'],
+          suspicionLevel: 0.74,
+          psychologicalNote: 'Hesitation suggests memory management.',
+        },
+      ],
+      overallAssessment: 'Unknown',
+      recommendedFollowUp: ['placeholder:follow-up', 'Press for route verification'],
+    },
+  ];
+
+  const html = renderToStaticMarkup(<BehavioralPatternsView patterns={data} />);
+  assertIncludes(html, 'Unnamed interviewee', 'fallback label should show for placeholder names');
+  assertIncludes(html, 'Press for route verification', 'non-placeholder follow-up remains visible');
+  assertNotIncludes(html, 'placeholder:Witness Alpha', 'placeholder text should be filtered out');
+})();
+
+(() => {
+  const gaps: EvidenceGap[] = [
+    {
+      category: 'forensic',
+      gapDescription: 'placeholder: dna missing',
+      whyItMatters: 'placeholder: reason',
+      howToFill: 'Submit clothing for modern testing',
+      priority: 'critical',
+      estimatedEffort: 'placeholder:effort',
+      potentialBreakthroughValue: 0.92,
+    },
+  ];
+
+  const html = renderToStaticMarkup(<EvidenceGapsView gaps={gaps} />);
+  assertIncludes(html, 'Effort not documented', 'fallback copy clarifies missing effort');
+  assertNotIncludes(html, 'placeholder: dna missing', 'gap description placeholder removed');
+  assertNotIncludes(html, 'placeholder: reason', 'why it matters placeholder removed');
+})();
+
+(() => {
+  const analysis: RelationshipNetworkAnalysis = {
+    nodes: [
+      {
+        name: 'placeholder:prime suspect',
+        role: 'suspect',
+        connections: [
+          {
+            to: 'Witness One',
+            type: 'friend',
+            strength: 0.8,
+            notes: 'placeholder:note',
+            suspicious: true,
+          },
+        ],
+        alibi: 'placeholder:alibi',
+        motive: 'Inheritance',
+        opportunity: 'Unknown',
+      },
+    ],
+    relationships: [
+      {
+        from: 'placeholder:prime suspect',
+        to: 'Witness One',
+        type: 'friend',
+        strength: 0.8,
+        notes: 'placeholder:note',
+        suspicious: true,
+      },
+    ],
+    hiddenConnections: [
+      {
+        person1: 'placeholder:prime suspect',
+        person2: 'Witness Two',
+        connectionType: 'business',
+        whyItMatters: 'placeholder:why',
+        hiddenHow: 'Withheld from reports',
+        discoveredFrom: ['Phone dump'],
+      },
+    ],
+    clusters: [],
+    insights: {
+      primaryConnectors: ['placeholder:prime suspect'],
+      potentialConflicts: ['prime suspect ⇄ Witness Two'],
+      recommendedFollowUp: ['Re-interview Witness Two'],
+    },
+  };
+
+  const html = renderToStaticMarkup(<RelationshipNetworkView analysis={analysis} />);
+  assertIncludes(html, 'Hidden connections to review', 'relationship view surfaces hidden links');
+  assertNotIncludes(html, 'placeholder:prime suspect', 'display text should suppress placeholder names');
+})();

--- a/tests/register-ts.js
+++ b/tests/register-ts.js
@@ -46,7 +46,7 @@ const compilerOptions = {
   moduleResolution: ts.ModuleResolutionKind.NodeNext,
 };
 
-require.extensions['.ts'] = function registerTsExtension(module, filename) {
+const registerTsExtension = function(module, filename) {
   const source = fs.readFileSync(filename, 'utf8');
   const transformed = ts.transpileModule(source, {
     compilerOptions,
@@ -55,3 +55,6 @@ require.extensions['.ts'] = function registerTsExtension(module, filename) {
   });
   return module._compile(transformed.outputText, filename);
 };
+
+require.extensions['.ts'] = registerTsExtension;
+require.extensions['.tsx'] = registerTsExtension;

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -4,3 +4,4 @@ require('./analyze-route.integration.test.ts');
 require('./timeline-analysis-route.test.ts');
 require('./ai-fallback.test.ts');
 require('./similar-cases-workflow.test.ts');
+require('./analysis-components.test.tsx');


### PR DESCRIPTION
## Summary
- replace the analysis history fallback JSON dump with dedicated views for behavioral patterns, evidence gaps, and relationship networks and sanitize placeholder values across the timeline UI
- add reusable display helpers plus lightweight component tests so placeholder strings never leak back into the UI
- ensure the analysis page selects the correct layout for each analysis type and filters out noisy values like "Unknown" or "placeholder:*"

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154a23f1dc83259fcfe606ad04be3e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new interactive analysis visualizations: behavioral patterns view (with suspicion filtering), evidence gaps view (with priority filtering), and relationship network view with connection mapping.
  * Enhanced all analysis displays with improved text sanitization, search functionality, and consistent fallback messaging to reduce null/undefined display issues.

* **Improvements**
  * Refined error handling for analysis submission with clearer messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->