### PR TITLE
Allow advanced analysis routes to fall back without Anthropic

### DIFF
--- a/app/api/cases/[caseId]/behavioral-patterns/route.ts
+++ b/app/api/cases/[caseId]/behavioral-patterns/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processBehavioralPatterns } from '@/lib/workflows/behavioral-patterns';
 import { runBackgroundTask } from '@/lib/background-tasks';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -44,26 +45,16 @@ export async function POST(
 
     console.log('[Behavioral Patterns API] Analysis requested for case:', caseId);
 
-    const anthropicKey =
-      process.env.ANTHROPIC_API_KEY || process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+    const { metadata: initialMetadata, usingFallback } = resolveAnalysisEngineMetadata(
+      'behavioral_patterns',
+      { requestedAt: new Date().toISOString() }
+    );
 
-    if (!anthropicKey) {
-      return withCors(
-        NextResponse.json(
-          {
-            error:
-              'Anthropic API key is not configured. Please set ANTHROPIC_API_KEY before running behavioral pattern analysis.',
-          },
-          { status: 503 }
-        )
+    if (usingFallback) {
+      console.warn(
+        '[Behavioral Patterns API] Anthropic API key missing. Scheduling heuristic fallback engine.'
       );
     }
-
-    const now = new Date().toISOString();
-    const initialMetadata = {
-      analysisType: 'behavioral_patterns',
-      requestedAt: now,
-    };
 
     const { data: job, error: jobError } = await supabaseServer
       .from('processing_jobs')
@@ -95,6 +86,7 @@ export async function POST(
         await processBehavioralPatterns({
           jobId: job.id,
           caseId,
+          requestedAt: initialMetadata.requestedAt,
         });
       },
       {
@@ -115,6 +107,7 @@ export async function POST(
           status: 'pending',
           message:
             'Behavioral pattern analysis workflow has been triggered. Check processing job status for progress.',
+          metadata: initialMetadata,
         },
         { status: 202 }
       )

--- a/app/api/cases/[caseId]/evidence-gaps/route.ts
+++ b/app/api/cases/[caseId]/evidence-gaps/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processEvidenceGaps } from '@/lib/workflows/evidence-gaps';
 import { runBackgroundTask } from '@/lib/background-tasks';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -44,26 +45,16 @@ export async function POST(
 
     console.log('[Evidence Gaps API] Analysis requested for case:', caseId);
 
-    const anthropicKey =
-      process.env.ANTHROPIC_API_KEY || process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+    const { metadata: initialMetadata, usingFallback } = resolveAnalysisEngineMetadata(
+      'evidence_gaps',
+      { requestedAt: new Date().toISOString() }
+    );
 
-    if (!anthropicKey) {
-      return withCors(
-        NextResponse.json(
-          {
-            error:
-              'Anthropic API key is not configured. Please set ANTHROPIC_API_KEY before running evidence gap analysis.',
-          },
-          { status: 503 }
-        )
+    if (usingFallback) {
+      console.warn(
+        '[Evidence Gaps API] Anthropic API key missing. Scheduling heuristic fallback engine.'
       );
     }
-
-    const now = new Date().toISOString();
-    const initialMetadata = {
-      analysisType: 'evidence_gaps',
-      requestedAt: now,
-    };
 
     const { data: job, error: jobError } = await supabaseServer
       .from('processing_jobs')
@@ -95,6 +86,7 @@ export async function POST(
         await processEvidenceGaps({
           jobId: job.id,
           caseId,
+          requestedAt: initialMetadata.requestedAt,
         });
       },
       {
@@ -115,6 +107,7 @@ export async function POST(
           status: 'pending',
           message:
             'Evidence gap analysis workflow has been triggered. Check processing job status for progress.',
+          metadata: initialMetadata,
         },
         { status: 202 }
       )

--- a/app/api/cases/[caseId]/interrogation-questions/route.ts
+++ b/app/api/cases/[caseId]/interrogation-questions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processInterrogationQuestions } from '@/lib/workflows/interrogation-questions';
 import { runBackgroundTask } from '@/lib/background-tasks';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -44,26 +45,16 @@ export async function POST(
 
     console.log('[Interrogation Questions API] Analysis requested for case:', caseId);
 
-    const anthropicKey =
-      process.env.ANTHROPIC_API_KEY || process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+    const { metadata: initialMetadata, usingFallback } = resolveAnalysisEngineMetadata(
+      'interrogation_questions',
+      { requestedAt: new Date().toISOString() }
+    );
 
-    if (!anthropicKey) {
-      return withCors(
-        NextResponse.json(
-          {
-            error:
-              'Anthropic API key is not configured. Please set ANTHROPIC_API_KEY before running interrogation question generation.',
-          },
-          { status: 503 }
-        )
+    if (usingFallback) {
+      console.warn(
+        '[Interrogation Questions API] Anthropic API key missing. Scheduling heuristic fallback engine.'
       );
     }
-
-    const now = new Date().toISOString();
-    const initialMetadata = {
-      analysisType: 'interrogation_questions',
-      requestedAt: now,
-    };
 
     const { data: job, error: jobError } = await supabaseServer
       .from('processing_jobs')
@@ -95,6 +86,7 @@ export async function POST(
         await processInterrogationQuestions({
           jobId: job.id,
           caseId,
+          requestedAt: initialMetadata.requestedAt,
         });
       },
       {
@@ -115,6 +107,7 @@ export async function POST(
           status: 'pending',
           message:
             'Interrogation question generation workflow has been triggered. Check processing job status for progress.',
+          metadata: initialMetadata,
         },
         { status: 202 }
       )

--- a/app/api/cases/[caseId]/overlooked-details/route.ts
+++ b/app/api/cases/[caseId]/overlooked-details/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processOverlookedDetails } from '@/lib/workflows/overlooked-details';
 import { runBackgroundTask } from '@/lib/background-tasks';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -44,26 +45,16 @@ export async function POST(
 
     console.log('[Overlooked Details API] Analysis requested for case:', caseId);
 
-    const anthropicKey =
-      process.env.ANTHROPIC_API_KEY || process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+    const { metadata: initialMetadata, usingFallback } = resolveAnalysisEngineMetadata(
+      'overlooked_details',
+      { requestedAt: new Date().toISOString() }
+    );
 
-    if (!anthropicKey) {
-      return withCors(
-        NextResponse.json(
-          {
-            error:
-              'Anthropic API key is not configured. Please set ANTHROPIC_API_KEY before running overlooked details analysis.',
-          },
-          { status: 503 }
-        )
+    if (usingFallback) {
+      console.warn(
+        '[Overlooked Details API] Anthropic API key missing. Scheduling heuristic fallback engine.'
       );
     }
-
-    const now = new Date().toISOString();
-    const initialMetadata = {
-      analysisType: 'overlooked_details',
-      requestedAt: now,
-    };
 
     const { data: job, error: jobError } = await supabaseServer
       .from('processing_jobs')
@@ -95,6 +86,7 @@ export async function POST(
         await processOverlookedDetails({
           jobId: job.id,
           caseId,
+          requestedAt: initialMetadata.requestedAt,
         });
       },
       {
@@ -115,6 +107,7 @@ export async function POST(
           status: 'pending',
           message:
             'Overlooked details analysis workflow has been triggered. Check processing job status for progress.',
+          metadata: initialMetadata,
         },
         { status: 202 }
       )

--- a/app/api/cases/[caseId]/relationship-network/route.ts
+++ b/app/api/cases/[caseId]/relationship-network/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processRelationshipNetwork } from '@/lib/workflows/relationship-network';
 import { runBackgroundTask } from '@/lib/background-tasks';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -44,26 +45,16 @@ export async function POST(
 
     console.log('[Relationship Network API] Analysis requested for case:', caseId);
 
-    const anthropicKey =
-      process.env.ANTHROPIC_API_KEY || process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+    const { metadata: initialMetadata, usingFallback } = resolveAnalysisEngineMetadata(
+      'relationship_network',
+      { requestedAt: new Date().toISOString() }
+    );
 
-    if (!anthropicKey) {
-      return withCors(
-        NextResponse.json(
-          {
-            error:
-              'Anthropic API key is not configured. Please set ANTHROPIC_API_KEY before running relationship network analysis.',
-          },
-          { status: 503 }
-        )
+    if (usingFallback) {
+      console.warn(
+        '[Relationship Network API] Anthropic API key missing. Scheduling heuristic fallback engine.'
       );
     }
-
-    const now = new Date().toISOString();
-    const initialMetadata = {
-      analysisType: 'relationship_network',
-      requestedAt: now,
-    };
 
     const { data: job, error: jobError } = await supabaseServer
       .from('processing_jobs')
@@ -95,6 +86,7 @@ export async function POST(
         await processRelationshipNetwork({
           jobId: job.id,
           caseId,
+          requestedAt: initialMetadata.requestedAt,
         });
       },
       {
@@ -115,6 +107,7 @@ export async function POST(
           status: 'pending',
           message:
             'Relationship network analysis workflow has been triggered. Check processing job status for progress.',
+          metadata: initialMetadata,
         },
         { status: 202 }
       )

--- a/app/api/cases/[caseId]/similar-cases/route.ts
+++ b/app/api/cases/[caseId]/similar-cases/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from 'next/server';
 import { supabaseServer } from '@/lib/supabase-server';
 import { processSimilarCases } from '@/lib/workflows/similar-cases';
 import { runBackgroundTask } from '@/lib/background-tasks';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Origin': '*',
@@ -44,26 +45,14 @@ export async function POST(
 
     console.log('[Similar Cases API] Analysis requested for case:', caseId);
 
-    const anthropicKey =
-      process.env.ANTHROPIC_API_KEY || process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+    const { metadata: initialMetadata, usingFallback } = resolveAnalysisEngineMetadata(
+      'similar_cases',
+      { requestedAt: new Date().toISOString() }
+    );
 
-    if (!anthropicKey) {
-      return withCors(
-        NextResponse.json(
-          {
-            error:
-              'Anthropic API key is not configured. Please set ANTHROPIC_API_KEY before running similar cases analysis.',
-          },
-          { status: 503 }
-        )
-      );
+    if (usingFallback) {
+      console.warn('[Similar Cases API] Anthropic API key missing. Scheduling heuristic fallback engine.');
     }
-
-    const now = new Date().toISOString();
-    const initialMetadata = {
-      analysisType: 'similar_cases',
-      requestedAt: now,
-    };
 
     const { data: job, error: jobError } = await supabaseServer
       .from('processing_jobs')
@@ -95,6 +84,7 @@ export async function POST(
         await processSimilarCases({
           jobId: job.id,
           caseId,
+          requestedAt: initialMetadata.requestedAt,
         });
       },
       {
@@ -115,6 +105,7 @@ export async function POST(
           status: 'pending',
           message:
             'Similar cases analysis workflow has been triggered. Check processing job status for progress.',
+          metadata: initialMetadata,
         },
         { status: 202 }
       )

--- a/lib/analysis-engine-metadata.ts
+++ b/lib/analysis-engine-metadata.ts
@@ -1,0 +1,35 @@
+import { isAnthropicConfigured } from '@/lib/anthropic-client';
+
+export type AnalysisEngineMetadata = {
+  analysisType: string;
+  requestedAt: string;
+  engine: 'anthropic_claude' | 'heuristic_fallback';
+  fallback?: boolean;
+  fallbackReason?: string;
+};
+
+interface ResolveOptions {
+  requestedAt?: string;
+}
+
+export function resolveAnalysisEngineMetadata(
+  analysisType: string,
+  options: ResolveOptions = {}
+): { metadata: AnalysisEngineMetadata; usingFallback: boolean } {
+  const anthropicConfigured = isAnthropicConfigured();
+  const metadata: AnalysisEngineMetadata = {
+    analysisType,
+    requestedAt: options.requestedAt ?? new Date().toISOString(),
+    engine: anthropicConfigured ? 'anthropic_claude' : 'heuristic_fallback',
+  };
+
+  if (!anthropicConfigured) {
+    metadata.fallback = true;
+    metadata.fallbackReason = 'missing_anthropic_credentials';
+  }
+
+  return {
+    metadata,
+    usingFallback: !anthropicConfigured,
+  };
+}

--- a/lib/workflows/behavioral-patterns.ts
+++ b/lib/workflows/behavioral-patterns.ts
@@ -11,22 +11,23 @@ import { supabaseServer } from '@/lib/supabase-server';
 import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { analyzeBehavioralPatterns } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 interface BehavioralPatternsParams {
   jobId: string;
   caseId: string;
+  requestedAt?: string;
 }
 
 export async function processBehavioralPatterns(params: BehavioralPatternsParams) {
   'use workflow';
 
-  const { jobId, caseId } = params;
+  const { jobId, caseId, requestedAt } = params;
 
   const totalUnits = 4; // Fetch, Extract, Analyze, Save
-  const initialMetadata = {
-    analysisType: 'behavioral_patterns',
-    requestedAt: new Date().toISOString(),
-  };
+  const { metadata: initialMetadata } = resolveAnalysisEngineMetadata('behavioral_patterns', {
+    requestedAt,
+  });
 
   try {
     async function initializeJob() {

--- a/lib/workflows/evidence-gaps.ts
+++ b/lib/workflows/evidence-gaps.ts
@@ -10,22 +10,23 @@
 import { supabaseServer } from '@/lib/supabase-server';
 import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { identifyEvidenceGaps } from '@/lib/cold-case-analyzer';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 interface EvidenceGapsParams {
   jobId: string;
   caseId: string;
+  requestedAt?: string;
 }
 
 export async function processEvidenceGaps(params: EvidenceGapsParams) {
   'use workflow';
 
-  const { jobId, caseId } = params;
+  const { jobId, caseId, requestedAt } = params;
 
   const totalUnits = 4; // Fetch, Prepare, Analyze, Save
-  const initialMetadata = {
-    analysisType: 'evidence_gaps',
-    requestedAt: new Date().toISOString(),
-  };
+  const { metadata: initialMetadata } = resolveAnalysisEngineMetadata('evidence_gaps', {
+    requestedAt,
+  });
 
   try {
     async function initializeJob() {

--- a/lib/workflows/forensic-retesting.ts
+++ b/lib/workflows/forensic-retesting.ts
@@ -15,10 +15,12 @@ import {
   sanitizeForensicRecommendations,
   summarizeForensicRecommendations,
 } from '@/lib/forensic-retesting-utils';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 interface ForensicRetestingParams {
   jobId: string;
   caseId: string;
+  requestedAt?: string;
 }
 
 /**
@@ -32,13 +34,12 @@ interface ForensicRetestingParams {
 export async function processForensicRetesting(params: ForensicRetestingParams) {
   'use workflow';
 
-  const { jobId, caseId } = params;
+  const { jobId, caseId, requestedAt } = params;
 
   const totalUnits = 4; // Fetch Case, Fetch Evidence, Analyze, Save
-  const initialMetadata = {
-    analysisType: 'forensic_retesting',
-    requestedAt: new Date().toISOString(),
-  };
+  const { metadata: initialMetadata } = resolveAnalysisEngineMetadata('forensic_retesting', {
+    requestedAt,
+  });
 
   try {
     // Step 1: Initialize job

--- a/lib/workflows/interrogation-questions.ts
+++ b/lib/workflows/interrogation-questions.ts
@@ -15,6 +15,7 @@ import {
 } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
 import type { Json } from '@/app/types/database';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 type PersonStatus = 'person_of_interest' | 'suspect' | 'witness' | 'victim';
 
@@ -245,6 +246,7 @@ function buildInterrogationPayload(
 interface InterrogationQuestionsParams {
   jobId: string;
   caseId: string;
+  requestedAt?: string;
 }
 
 /**
@@ -258,13 +260,12 @@ interface InterrogationQuestionsParams {
 export async function processInterrogationQuestions(params: InterrogationQuestionsParams) {
   'use workflow';
 
-  const { jobId, caseId } = params;
+  const { jobId, caseId, requestedAt } = params;
 
   const totalUnits = 4; // Fetch, Extract, Analyze, Save
-  const initialMetadata = {
-    analysisType: 'interrogation_questions',
-    requestedAt: new Date().toISOString(),
-  };
+  const { metadata: initialMetadata } = resolveAnalysisEngineMetadata('interrogation_questions', {
+    requestedAt,
+  });
 
   try {
     // Step 1: Initialize job

--- a/lib/workflows/overlooked-details.ts
+++ b/lib/workflows/overlooked-details.ts
@@ -11,10 +11,12 @@ import { supabaseServer } from '@/lib/supabase-server';
 import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { findOverlookedDetails } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 interface OverlookedDetailsParams {
   jobId: string;
   caseId: string;
+  requestedAt?: string;
 }
 
 async function updateProcessingJob(jobId: string, updates: Record<string, any>) {
@@ -32,13 +34,12 @@ async function updateProcessingJob(jobId: string, updates: Record<string, any>) 
 export async function processOverlookedDetails(params: OverlookedDetailsParams) {
   'use workflow';
 
-  const { jobId, caseId } = params;
+  const { jobId, caseId, requestedAt } = params;
 
   const totalUnits = 4; // Fetch, Extract, Analyze, Save
-  const initialMetadata = {
-    analysisType: 'overlooked_details',
-    requestedAt: new Date().toISOString(),
-  };
+  const { metadata: initialMetadata } = resolveAnalysisEngineMetadata('overlooked_details', {
+    requestedAt,
+  });
 
   try {
     // Step 1: Initialize job

--- a/lib/workflows/relationship-network.ts
+++ b/lib/workflows/relationship-network.ts
@@ -14,10 +14,12 @@ import {
   RelationshipNetworkAnalysis,
 } from '@/lib/cold-case-analyzer';
 import { extractMultipleDocuments } from '@/lib/document-parser';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 interface RelationshipNetworkParams {
   jobId: string;
   caseId: string;
+  requestedAt?: string;
 }
 
 type RelationshipNetworkSummaryMetadata = {
@@ -42,13 +44,12 @@ async function updateProcessingJob(jobId: string, updates: Record<string, any>) 
 export async function processRelationshipNetwork(params: RelationshipNetworkParams) {
   'use workflow';
 
-  const { jobId, caseId } = params;
+  const { jobId, caseId, requestedAt } = params;
 
   const totalUnits = 4; // Fetch, Extract, Analyze, Save
-  const initialMetadata = {
-    analysisType: 'relationship_network',
-    requestedAt: new Date().toISOString(),
-  };
+  const { metadata: initialMetadata } = resolveAnalysisEngineMetadata('relationship_network', {
+    requestedAt,
+  });
 
   try {
     // Step 1: Initialize job

--- a/lib/workflows/similar-cases.ts
+++ b/lib/workflows/similar-cases.ts
@@ -13,10 +13,12 @@ import { supabaseServer } from '@/lib/supabase-server';
 import { updateProcessingJob as updateProcessingJobRecord } from '@/lib/update-processing-job';
 import { findSimilarCases } from '@/lib/cold-case-analyzer';
 import type { CaseSimilarity } from '@/lib/cold-case-analyzer';
+import { resolveAnalysisEngineMetadata } from '@/lib/analysis-engine-metadata';
 
 interface SimilarCasesParams {
   jobId: string;
   caseId: string;
+  requestedAt?: string;
 }
 
 type CaseRecord = {
@@ -485,13 +487,12 @@ export function calculateSimilarCaseSummary(similarCases: CaseSimilarity[]) {
 export async function processSimilarCases(params: SimilarCasesParams) {
   'use workflow';
 
-  const { jobId, caseId } = params;
+  const { jobId, caseId, requestedAt } = params;
 
   const totalUnits = 4; // Fetch Current, Fetch Others, Analyze, Save
-  const initialMetadata = {
-    analysisType: 'similar_cases',
-    requestedAt: new Date().toISOString(),
-  };
+  const { metadata: initialMetadata } = resolveAnalysisEngineMetadata('similar_cases', {
+    requestedAt,
+  });
 
   try {
     // Step 1: Initialize job

--- a/tests/advanced-analysis-fallbacks.test.ts
+++ b/tests/advanced-analysis-fallbacks.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+
+interface RouteTestConfig {
+  name: string;
+  routePath: string;
+  workflowPath: string;
+  workflowExport: string;
+}
+
+const ROUTES: RouteTestConfig[] = [
+  {
+    name: 'behavioral patterns',
+    routePath: '../app/api/cases/[caseId]/behavioral-patterns/route.ts',
+    workflowPath: '../lib/workflows/behavioral-patterns.ts',
+    workflowExport: 'processBehavioralPatterns',
+  },
+  {
+    name: 'evidence gaps',
+    routePath: '../app/api/cases/[caseId]/evidence-gaps/route.ts',
+    workflowPath: '../lib/workflows/evidence-gaps.ts',
+    workflowExport: 'processEvidenceGaps',
+  },
+  {
+    name: 'forensic retesting',
+    routePath: '../app/api/cases/[caseId]/forensic-retesting/route.ts',
+    workflowPath: '../lib/workflows/forensic-retesting.ts',
+    workflowExport: 'processForensicRetesting',
+  },
+  {
+    name: 'interrogation questions',
+    routePath: '../app/api/cases/[caseId]/interrogation-questions/route.ts',
+    workflowPath: '../lib/workflows/interrogation-questions.ts',
+    workflowExport: 'processInterrogationQuestions',
+  },
+  {
+    name: 'overlooked details',
+    routePath: '../app/api/cases/[caseId]/overlooked-details/route.ts',
+    workflowPath: '../lib/workflows/overlooked-details.ts',
+    workflowExport: 'processOverlookedDetails',
+  },
+  {
+    name: 'relationship network',
+    routePath: '../app/api/cases/[caseId]/relationship-network/route.ts',
+    workflowPath: '../lib/workflows/relationship-network.ts',
+    workflowExport: 'processRelationshipNetwork',
+  },
+  {
+    name: 'similar cases',
+    routePath: '../app/api/cases/[caseId]/similar-cases/route.ts',
+    workflowPath: '../lib/workflows/similar-cases.ts',
+    workflowExport: 'processSimilarCases',
+  },
+];
+
+function stubModule(modulePath: string, exports: Record<string, any>) {
+  const original = require.cache[modulePath];
+  require.cache[modulePath] = {
+    id: modulePath,
+    filename: modulePath,
+    loaded: true,
+    exports,
+  } as NodeModule;
+  return () => {
+    if (original) {
+      require.cache[modulePath] = original;
+    } else {
+      delete require.cache[modulePath];
+    }
+  };
+}
+
+async function run() {
+  const originalKey = process.env.ANTHROPIC_API_KEY;
+  const originalPublicKey = process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+
+  const supabaseModulePath = require.resolve('../lib/supabase-server.ts');
+  const backgroundModulePath = require.resolve('../lib/background-tasks.ts');
+
+  try {
+    for (const config of ROUTES) {
+      const workflowModulePath = require.resolve(config.workflowPath);
+      const routeModulePath = require.resolve(config.routePath);
+
+      const supabaseStub = {
+        from(table: string) {
+          if (table !== 'processing_jobs') {
+            throw new Error(`Unexpected table access: ${table}`);
+          }
+
+          return {
+            insert() {
+              return {
+                select() {
+                  return {
+                    single() {
+                      return Promise.resolve({ data: { id: 'job-123' }, error: null });
+                    },
+                  };
+                },
+              };
+            },
+          };
+        },
+      };
+
+      let workflowInvocation: any = null;
+      const cleanupSupabase = stubModule(supabaseModulePath, { supabaseServer: supabaseStub });
+      const cleanupWorkflow = stubModule(workflowModulePath, {
+        [config.workflowExport]: async (params: any) => {
+          workflowInvocation = params;
+        },
+      });
+      const cleanupBackground = stubModule(backgroundModulePath, {
+        runBackgroundTask: async (task: () => Promise<void>) => {
+          await task();
+        },
+      });
+
+      delete require.cache[routeModulePath];
+      const routeModule = require(routeModulePath);
+
+      try {
+        const response = await routeModule.POST({} as any, { params: { caseId: 'case-test' } });
+        assert.equal(response.status, 202, `${config.name} route should respond with 202`);
+
+        const payload = await response.json();
+        assert.equal(payload.metadata.fallback, true, `${config.name} metadata should flag fallback mode`);
+        assert.equal(
+          payload.metadata.fallbackReason,
+          'missing_anthropic_credentials',
+          `${config.name} metadata should include fallback reason`
+        );
+        assert.equal(
+          payload.metadata.engine,
+          'heuristic_fallback',
+          `${config.name} metadata should expose fallback engine`
+        );
+
+        assert.ok(workflowInvocation, `${config.name} workflow should be invoked even without Anthropic key`);
+        assert.equal(
+          workflowInvocation.requestedAt,
+          payload.metadata.requestedAt,
+          `${config.name} workflow should inherit requestedAt metadata`
+        );
+      } finally {
+        cleanupSupabase();
+        cleanupWorkflow();
+        cleanupBackground();
+        delete require.cache[routeModulePath];
+      }
+    }
+  } finally {
+    if (originalKey) {
+      process.env.ANTHROPIC_API_KEY = originalKey;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+
+    if (originalPublicKey) {
+      process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY = originalPublicKey;
+    } else {
+      delete process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
+    }
+
+    delete require.cache[supabaseModulePath];
+    delete require.cache[backgroundModulePath];
+  }
+}
+
+run()
+  .then(() => {
+    if (process.env.DEBUG_TESTS) {
+      console.log('advanced analysis routes fall back without Anthropic credentials ✅');
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -4,3 +4,4 @@ require('./analyze-route.integration.test.ts');
 require('./timeline-analysis-route.test.ts');
 require('./ai-fallback.test.ts');
 require('./similar-cases-workflow.test.ts');
+require('./advanced-analysis-fallbacks.test.ts');


### PR DESCRIPTION
## Summary
- allow every advanced case analysis API to schedule its workflow even when Anthropic credentials are missing and return metadata describing the fallback engine
- ensure the background workflows reuse the same metadata so fallback provenance is persisted in processing job records
- add regression coverage that posts each route without an Anthropic key and asserts the fallback path is taken

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69154a2290b08325a41259699284656e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced centralized metadata resolution system for analysis workflows, enabling better tracking of analysis requests and engine selection.

* **Bug Fixes**
  * Analysis endpoints now gracefully fall back to alternative processing when primary analysis engines are unavailable, instead of returning errors. Warning logs are recorded for fallback usage.

* **Tests**
  * Added test coverage for fallback behavior across analysis endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->