### PR TITLE
Fix timeline board timestamps

### DIFF
--- a/lib/datetime-utils.ts
+++ b/lib/datetime-utils.ts
@@ -1,0 +1,57 @@
+export function toISODateTime(dateInput?: string | null, timeInput?: string | null): string | null {
+  if (!dateInput && !timeInput) {
+    return null;
+  }
+
+  const parseDate = (value?: string | null) => {
+    if (!value) return null;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  };
+
+  // If only one argument is provided, interpret it as a combined date/time value
+  if (dateInput && !timeInput) {
+    const parsed = parseDate(dateInput);
+    return parsed ? parsed.toISOString() : null;
+  }
+
+  const baseDate = parseDate(dateInput);
+  if (!baseDate) {
+    const fallback = parseDate(timeInput);
+    return fallback ? fallback.toISOString() : null;
+  }
+
+  if (!timeInput) {
+    return baseDate.toISOString();
+  }
+
+  // Attempt to parse the time input directly as a timestamp first
+  const timeAsDate = parseDate(timeInput);
+  if (timeAsDate) {
+    return timeAsDate.toISOString();
+  }
+
+  // Fallback to parsing expressions like "8:30 PM" or "14:05"
+  const match = timeInput.match(/(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(am|pm)?/i);
+  if (match) {
+    let hours = parseInt(match[1], 10);
+    const minutes = match[2] ? parseInt(match[2], 10) : 0;
+    const seconds = match[3] ? parseInt(match[3], 10) : 0;
+    const meridiem = match[4]?.toLowerCase();
+
+    if (meridiem === 'pm' && hours < 12) hours += 12;
+    if (meridiem === 'am' && hours === 12) hours = 0;
+
+    baseDate.setHours(hours, minutes, seconds, 0);
+    return baseDate.toISOString();
+  }
+
+  return baseDate.toISOString();
+}
+
+export function toISODateString(dateInput?: string | null): string | null {
+  if (!dateInput) return null;
+  const parsed = new Date(dateInput);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString().split('T')[0];
+}

--- a/lib/jobs/populate-investigation-board.ts
+++ b/lib/jobs/populate-investigation-board.ts
@@ -13,6 +13,7 @@ import { supabaseServer } from '@/lib/supabase-server';
 import { analyzeCaseDocuments } from '@/lib/ai-analysis';
 import { extractDocumentContent, extractDocumentContentFromBuffer } from '@/lib/document-parser';
 import { isLikelyNonPersonEntity } from '@/lib/text-heuristics';
+import { toISODateTime } from '@/lib/datetime-utils';
 import OpenAI from 'openai';
 
 type StepRunner = {
@@ -1141,26 +1142,6 @@ function determineEventType(description: string, entityNames: string[]): Extract
   if (entityNames.some((name) => name.toLowerCase().includes('victim'))) return 'victim_action';
   if (lower.includes('alibi') || lower.includes('claimed')) return 'suspect_movement';
   return 'other';
-}
-
-function toISODateTime(dateInput?: string | null, timeInput?: string | null): string | null {
-  if (!dateInput) return null;
-  const date = new Date(dateInput);
-  if (Number.isNaN(date.getTime())) return null;
-
-  if (timeInput) {
-    const match = timeInput.match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)?/i);
-    if (match) {
-      let hours = parseInt(match[1], 10);
-      const minutes = match[2] ? parseInt(match[2], 10) : 0;
-      const meridiem = match[3]?.toLowerCase();
-      if (meridiem === 'pm' && hours < 12) hours += 12;
-      if (meridiem === 'am' && hours === 12) hours = 0;
-      date.setHours(hours, minutes, 0, 0);
-    }
-  }
-
-  return date.toISOString();
 }
 
 function createEventKey(title?: string | null, isoTime?: string | null, description?: string | null) {


### PR DESCRIPTION
## Summary
- add shared utilities for normalizing timeline dates and times into ISO strings
- ensure the timeline analysis workflow converts event dates/times to ISO values before saving them so the board can render readable timestamps
- reuse the shared normalization logic inside the investigation board population job to avoid diverging formats

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915851f9d5483259202eef9cc5b85d0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved date and time utility functions with enhanced input validation and ISO format consistency.
  * Streamlined timeline event normalization to ensure reliable date and time handling across investigation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->